### PR TITLE
Remove closure from format_args! call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl Drop for DefaultLogger {
 /// It is not recommended to call this function directly, rather it should be
 /// invoked through the logging family of macros.
 #[doc(hidden)]
-pub fn log(level: u32, loc: &'static LogLocation, args: &fmt::Arguments) {
+pub fn log(level: u32, loc: &'static LogLocation, args: fmt::Arguments) {
     // Test the literal string from args against the current filter, if there
     // is one.
     match unsafe { FILTER.as_ref() } {
@@ -326,7 +326,7 @@ pub struct LogRecord<'a> {
     pub level: LogLevel,
 
     /// The arguments from the log line.
-    pub args: &'a fmt::Arguments<'a>,
+    pub args: fmt::Arguments<'a>,
 
     /// The file of where the LogRecord originated.
     pub file: &'a str,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -60,7 +60,7 @@ macro_rules! log {
         };
         let lvl = $lvl;
         if log_enabled!(lvl) {
-            format_args!(|args| { ::log::log(lvl, &LOC, args) }, $($arg)+)
+            ::log::log(lvl, &LOC, format_args!($($arg)+));
         }
     })
 }


### PR DESCRIPTION
This fixes up `format_args!` after a recent breaking change in [rust-lang PR#20136](https://github.com/rust-lang/rust/pull/20136)
The logger now takes `fmt::Arguments` by value and the `log!` macro is rewritten to pass arguments directly to `format_args!` with no intermediate closure.
