### PR TITLE
Fix log filtering

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,6 +11,9 @@
 ///
 /// This macro will generically log with the specified `LogLevel` and `format!`
 /// based argument list.
+///
+/// The `log_level` cfg can be used to statically disable logging at various
+/// levels.
 #[macro_export]
 macro_rules! log {
     ($lvl:expr, $($arg:tt)+) => ({
@@ -20,7 +23,12 @@ macro_rules! log {
             module_path: module_path!(),
         };
         let lvl = $lvl;
-        if lvl <= $crate::max_log_level() {
+        if !cfg!(log_level = "off") &&
+                (lvl <= $crate::LogLevel::Error || !cfg!(log_level = "error")) &&
+                (lvl <= $crate::LogLevel::Warn || !cfg!(log_level = "warn")) &&
+                (lvl <= $crate::LogLevel::Debug || !cfg!(log_level = "debug")) &&
+                (lvl <= $crate::LogLevel::Info || !cfg!(log_level = "info")) &&
+                lvl <= $crate::max_log_level() {
             $crate::log(lvl, &LOC, format_args!($($arg)+))
         }
     })
@@ -28,79 +36,59 @@ macro_rules! log {
 
 /// Logs a message at the error level.
 ///
-/// Logging through this macro is disabled if the `log_level = "off"` cfg is
+/// Logging at this level is disabled if the `log_level = "off"` cfg is
 /// present.
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => (
-        if !cfg!(any(log_level = "off")) {
-            log!($crate::LogLevel::Error, $($arg)*);
-        }
+        log!($crate::LogLevel::Error, $($arg)*);
     )
 }
 
 /// Logs a message at the warn level.
 ///
-/// Logging through this macro is disabled if any of the following cfgs are
-/// present: `log_level = "off"` or `log_level = "error"`.
+/// Logging at this level is disabled if any of the following cfgs are present:
+/// `log_level = "off"` or `log_level = "error"`.
 #[macro_export]
 macro_rules! warn {
     ($($arg:tt)*) => (
-        if !cfg!(any(log_level = "off",
-                     log_level = "error")) {
-            log!($crate::LogLevel::Warn, $($arg)*);
-        }
+        log!($crate::LogLevel::Warn, $($arg)*);
     )
 }
 
 /// Logs a message at the info level.
 ///
-/// Logging through this macro is disabled if any of the following cfgs are
-/// present: `log_level = "off"`, `log_level = "error"`, or
+/// Logging at this level is disabled if any of the following cfgs are present:
+/// `log_level = "off"`, `log_level = "error"`, or
 /// `log_level = "warn"`.
 #[macro_export]
 macro_rules! info {
     ($($arg:tt)*) => (
-        if !cfg!(any(log_level = "off",
-                     log_level = "error",
-                     log_level = "warn")) {
-            log!($crate::LogLevel::Info, $($arg)*);
-        }
+        log!($crate::LogLevel::Info, $($arg)*);
     )
 }
 
 /// Logs a message at the debug level.
 ///
-/// Logging through this macro is disabled if any of the following cfgs are
-/// present: `log_level = "off"`, `log_level = "error"`, `log_level = "warn"`,
+/// Logging at this level is disabled if any of the following cfgs are present:
+/// `log_level = "off"`, `log_level = "error"`, `log_level = "warn"`,
 /// or `log_level = "info"`.
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => (
-        if !cfg!(any(log_level = "off",
-                     log_level = "error",
-                     log_level = "warn",
-                     log_level = "info")) {
-            log!($crate::LogLevel::Debug, $($arg)*);
-        }
+        log!($crate::LogLevel::Debug, $($arg)*);
     )
 }
 
 /// Logs a message at the trace level.
 ///
-/// Logging through this macro is disabled if any of the following cfgs are
-/// present: `log_level = "off"`, `log_level = "error"`, `log_level = "warn"`,
+/// Logging at this level is disabled if any of the following cfgs are present:
+/// `log_level = "off"`, `log_level = "error"`, `log_level = "warn"`,
 /// `log_level = "info"`, or `log_level = "debug"`.
 #[macro_export]
 macro_rules! trace {
     ($($arg:tt)*) => (
-        if !cfg!(any(log_level = "off",
-                     log_level = "error",
-                     log_level = "warn",
-                     log_level = "info",
-                     log_level = "debug")) {
-            log!($crate::LogLevel::Debug, $($arg)*);
-        }
+        log!($crate::LogLevel::Debug, $($arg)*);
     )
 }
 


### PR DESCRIPTION
We weren't filtering in log! itself, at which point we can remove the
checks in the other macros.