### PR TITLE
Implemented Error trait for SetLoggerError.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@
 
 use std::ascii::AsciiExt;
 use std::cmp;
+use std::error;
 use std::fmt;
 use std::mem;
 use std::ops::Deref;
@@ -556,6 +557,10 @@ impl fmt::Display for SetLoggerError {
     }
 }
 
+impl error::Error for SetLoggerError {
+    fn description(&self) -> &str { "set_logger() called multiple times" }
+}
+
 struct LoggerGuard(usize);
 
 impl Drop for LoggerGuard {
@@ -608,7 +613,8 @@ pub fn log(level: LogLevel, loc: &LogLocation, args: fmt::Arguments) {
 
 #[cfg(test)]
 mod tests {
-     use super::{LogLevel, LogLevelFilter};
+     use std::error::Error;
+     use super::{LogLevel, LogLevelFilter, SetLoggerError};
 
      #[test]
      fn test_loglevelfilter_from_str() {
@@ -690,5 +696,11 @@ mod tests {
      fn test_to_log_level_filter() {
          assert_eq!(LogLevelFilter::Error, LogLevel::Error.to_log_level_filter());
          assert_eq!(LogLevelFilter::Trace, LogLevel::Trace.to_log_level_filter());
+     }
+
+     #[test]
+     fn test_error_trait() {
+         let e = SetLoggerError(());
+         assert_eq!(e.description(), "set_logger() called multiple times");
      }
 }


### PR DESCRIPTION
This simple change implements and tests the `std::error::Error` trait for `log::SetLoggerError`.  This enables use of the [improved error handling](http://lucumr.pocoo.org/2014/11/6/error-handling-in-rust/) pattern and the `try!` macro.  I have tested it against my code base, which required rebuilding and testing 9 crates not my own. Examples: [rand](https://github.com/rust-lang/rand), [rustc-serialize](https://github.com/rust-lang/rustc-serialize), [rust-postgres](https://github.com/sfackler/rust-postgres), and [time](https://github.com/rust-lang/time).  Unless different `Error::description()` text is desired, it appears is good to go.