### PR TITLE
API overhaul round 2

### DIFF
--- a/env/src/lib.rs
+++ b/env/src/lib.rs
@@ -161,7 +161,7 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &LogRecord) {
-        if !self.enabled(record.level(), record.location().module_path) {
+        if !self.enabled(record.level(), record.location().module_path()) {
             return;
         }
 
@@ -174,7 +174,7 @@ impl Log for Logger {
         let _ = writeln!(&mut *self.out.lock().unwrap(),
                          "{}:{}: {}",
                          record.level(),
-                         record.location().module_path,
+                         record.location().module_path(),
                          record.args());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //!     }
 //!
 //!     fn log(&self, record: &LogRecord) {
-//!         if self.enabled(record.level(), record.location().module_path) {
+//!         if self.enabled(record.level(), record.location().module_path()) {
 //!             println!("{} - {}", record.level(), record.args());
 //!         }
 //!     }
@@ -466,14 +466,37 @@ pub trait Log: Sync+Send {
 }
 
 /// The location of a log message.
+///
+/// # Warning
+///
+/// The fields of this struct are public so that they may be initialized by the
+/// `log!` macro. They are subject to change at any time and should never be
+/// accessed directly.
 #[derive(Copy, Clone, Debug)]
 pub struct LogLocation {
+    #[doc(hidden)]
+    pub __module_path: &'static str,
+    #[doc(hidden)]
+    pub __file: &'static str,
+    #[doc(hidden)]
+    pub __line: u32,
+}
+
+impl LogLocation {
     /// The module path of the message.
-    pub module_path: &'static str,
+    pub fn module_path(&self) -> &str {
+        self.__module_path
+    }
+
     /// The source file containing the message.
-    pub file: &'static str,
+    pub fn file(&self) -> &str {
+        self.__file
+    }
+
     /// The line containing the message.
-    pub line: u32,
+    pub fn line(&self) -> u32 {
+        self.__line
+    }
 }
 
 /// A token providing read and write access to the global maximum log level

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,16 +421,6 @@ pub struct LogRecord<'a> {
 }
 
 impl<'a> LogRecord<'a> {
-    /// Creates a new `LogRecord`.
-    pub fn new(level: LogLevel, location: &'a LogLocation, args: fmt::Arguments<'a>)
-               -> LogRecord<'a> {
-        LogRecord {
-            level: level,
-            location: location,
-            args: args,
-        }
-    }
-
     /// The message body.
     pub fn args(&self) -> &fmt::Arguments<'a> {
         &self.args
@@ -635,7 +625,7 @@ pub fn enabled(level: LogLevel, module: &str) -> bool {
 /// `warn!`, `info!`, `debug!`, and `trace!` macros should be used instead.
 pub fn log(level: LogLevel, loc: &LogLocation, args: fmt::Arguments) {
     if let Some(logger) = logger() {
-        logger.log(&LogRecord::new(level, loc, args))
+        logger.log(&LogRecord { level: level, location: loc, args: args })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,12 +606,11 @@ fn logger() -> Option<LoggerGuard> {
     }
 }
 
-/// Determines if the current logger will ignore a log message at the specified
-/// level from the specified module.
-///
-/// This should not typically be called directly. The `log_enabled!` macro
-/// should be used instead.
-pub fn enabled(level: LogLevel, module: &str) -> bool {
+// WARNING
+// This is not considered part of the crate's public API. It is subject to
+// change at any time.
+#[doc(hidden)]
+pub fn __enabled(level: LogLevel, module: &str) -> bool {
     if let Some(logger) = logger() {
         logger.enabled(level, module)
     } else {
@@ -619,11 +618,11 @@ pub fn enabled(level: LogLevel, module: &str) -> bool {
     }
 }
 
-/// Logs a message.
-///
-/// This should not typically be called directly. The `log!`, `error!`,
-/// `warn!`, `info!`, `debug!`, and `trace!` macros should be used instead.
-pub fn log(level: LogLevel, loc: &LogLocation, args: fmt::Arguments) {
+// WARNING
+// This is not considered part of the crate's public API. It is subject to
+// change at any time.
+#[doc(hidden)]
+pub fn __log(level: LogLevel, loc: &LogLocation, args: fmt::Arguments) {
     if let Some(logger) = logger() {
         logger.log(&LogRecord { level: level, location: loc, args: args })
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,9 +18,9 @@
 macro_rules! log {
     ($lvl:expr, $($arg:tt)+) => ({
         static LOC: $crate::LogLocation = $crate::LogLocation {
-            line: line!(),
-            file: file!(),
-            module_path: module_path!(),
+            __line: line!(),
+            __file: file!(),
+            __module_path: module_path!(),
         };
         let lvl = $lvl;
         if !cfg!(log_level = "off") &&

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@ macro_rules! log {
                 (lvl <= $crate::LogLevel::Debug || !cfg!(log_level = "debug")) &&
                 (lvl <= $crate::LogLevel::Info || !cfg!(log_level = "info")) &&
                 lvl <= $crate::max_log_level() {
-            $crate::log(lvl, &LOC, format_args!($($arg)+))
+            $crate::__log(lvl, &LOC, format_args!($($arg)+))
         }
     })
 }
@@ -123,6 +123,6 @@ macro_rules! log_enabled {
             (lvl <= $crate::LogLevel::Debug || !cfg!(log_level = "debug")) &&
             (lvl <= $crate::LogLevel::Info || !cfg!(log_level = "info")) &&
             lvl <= $crate::max_log_level() &&
-            $crate::enabled(lvl, module_path!())
+            $crate::__enabled(lvl, module_path!())
     })
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
 
 use std::sync::{Arc, Mutex};
-use log::{LogLevel, set_logger, LogLevelFilter, Log, LogRecord};
+use log::{LogLevel, set_logger, LogLevelFilter, Log, LogRecord, LogMetadata};
 use log::MaxLogLevelFilter;
 
 struct State {
@@ -10,7 +10,7 @@ struct State {
 }
 
 impl Log for Arc<State> {
-    fn enabled(&self, _level: LogLevel, _module: &str) -> bool {
+    fn enabled(&self, _: &LogMetadata) -> bool {
         true
     }
 


### PR DESCRIPTION
This PR contains a series of commits which add functionality and future-proofing. There are breaking changes for libraries implementing `Log` but not for libraries using the logging macros. I opened this as a PR instead of filing an issue because I think it's a bit easier to talk about when looking at an actual implementation. It deserves some discussion before merging for sure.

### "Encapsulate" `LogLocation` by mangling the field names and making them `#[doc(hidden)]`.
We may want to add to this struct in the future (maybe function name if that macro ever gets added), or replace the internals with something that extracts information from debuginfo for example. It's a bit suboptimal since we can't actually make the fields private, but I think it's good enough that we can alter the struct backwards compatibly.

### Remove `LogRecord::new`
I added this because it made it easier to test logger implementations, but it cripples the log crate's ability to add features without breaking backwards compatibility. Logger implementations can restructure a tiny bit to make testing easier (translate a LogRecord to their own internal type for example).

### Make entry point functions "private"
The `log` and `enabled` functions were previously fully public, which inhibits our ability to add features. I took a similar strategy here as I did for `LogLocation` of mangling the names and marking them `#[doc(hidden)]`.

### Add the concept of a "target" to log directives
Most of the time when logging, using the current module path as the "target" for filtering makes sense. However, you sometimes need more fine-grained control over logging messages. For example, consider a "router" function in a web server. We want to have normal diagnostic loggging calls, but also provide a request log:
```rust
fn route(url: Request) {
     debug!("starting routing for {:?}", url);

     match find_handler(&url) {
          Ok(handler) => {
              debug!("got handler for {:?}", url);
              info!(target: "request_log", "{} - {}", url, handler);
              handler.handle(url);
          }
          Err(err) => error!("error routing {:?}", url),
     }
}
```
The `debug!` and `error!` calls will end up with a target set to the module path (`app::router` or whatever), but the `info!` call will instead have a target of `request_log`. It's then extremely easy to set up a logging framework like `log4rs` to pipe the `request_log` target to a separate file from the rest of the log output.

#### Open Question
One interesting note here is that log4j derived logging implementations call these "loggers", not "targets". The overall framework is typically called a "logging context" I believe. It would be kind of nice to mirror that terminology for familiarity's sake, but it would require a much larger API and documentation change (renaming `set_logger` to `set_context`, etc). Thoughts?

### Encapsulate data passed to `Log::enabled`
We were previously passing the log level and module path (now target) to `Log::enabled`. We may want to add more "selection" metadata to a log event in the future, however. For example, in slf4j, you can pass `Marker` objects when logging which can provide more flexibility than just tweaking the target would. I'm not familiar enough with them to add them now, but we should at least make sure that we'll be able to.