### PR TITLE
Respect padding for LogLevel names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl FromStr for LogLevel {
 
 impl fmt::Display for LogLevel {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", LOG_LEVEL_NAMES[*self as usize])
+        fmt.pad(LOG_LEVEL_NAMES[*self as usize])
     }
 }
 


### PR DESCRIPTION
LogLevel names are frequently output in log files and the ability to pad them to a width helps.