### PR TITLE
Remove dependence on std::rt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ A lightweight logging facade for Rust
 [[test]]
 name = "filters"
 harness = false
+
+[dependencies]
+libc = "0.1"


### PR DESCRIPTION
This moves the usage of `rt::at_exit` to `libc::atexit` instead. It's not
looking like it's likely for `rt::at_exit` to be stable at 1.0, and
`libc::atexit` is at least supported on major platforms.