### PR TITLE
Change dependency on libc to one on shutdown_hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: rust
 sudo: false
 rust:
-  - 1.0.0
+  - 1.1.0
+  - stable
   - beta
   - nightly
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ name = "filters"
 harness = false
 
 [dependencies]
-libc = "0.1"
+shutdown_hooks = "0.1.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,9 @@
        html_root_url = "http://doc.rust-lang.org/log/")]
 #![warn(missing_docs)]
 
-extern crate libc;
+extern crate shutdown_hooks;
+
+use shutdown_hooks::add_shutdown_hook;
 
 use std::ascii::AsciiExt;
 use std::cmp;
@@ -587,9 +589,7 @@ pub fn set_logger<M>(make_logger: M) -> Result<(), SetLoggerError>
     let logger = unsafe { mem::transmute::<Box<Box<Log>>, usize>(logger) };
     LOGGER.store(logger, Ordering::SeqCst);
 
-    unsafe {
-        assert_eq!(libc::atexit(shutdown), 0);
-    }
+    assert!(add_shutdown_hook(shutdown));
     return Ok(());
 
     extern fn shutdown() {


### PR DESCRIPTION
This ~~may cause~~ causes an inherited minimum Rust version of 1.1.0 due to the inclusion of std::os::raw::c_int as a return value of the (non-public) atexit() function. ~~I need Travis to let me know.~~ Perhaps this means this shouldn't be included in the 0.3 series but in 0.4?

If I end up changing the method signature in the future, I'll update the log crate within an hour. I probably won't need to, though :)

Edit: Updated travis.yml to test on 1.1.0 as a minimum and also the "current stable" version in the future