### PR TITLE
Add instructions and example for using env_logger in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,78 @@ fn main() {
     // ...
 }
 ```
+
+## In tests
+
+Tests can use the `env_logger` crate to see log messages generated during that test:
+
+```toml
+[dependencies]
+log = "0.3"
+
+[dev-dependencies]
+env_logger = "0.3"
+```
+
+```rust
+#[macro_use]
+extern crate log;
+
+fn add_one(num: i32) -> i32 {
+    info!("add_one called with {}", num);
+    num + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate env_logger;
+
+    #[test]
+    fn it_adds_one() {
+        env_logger::init().unwrap();
+        info!("can log from the test too");
+        assert_eq!(3, add_one(2));
+    }
+
+    #[test]
+    fn it_handles_negative_numbers() {
+      assert_eq!(-7, add_one(-8));
+    }
+}
+```
+
+Assuming the module under test is called `my_lib`, running the tests with the
+`RUST_LOG` filtering to info messages from this module looks like:
+
+```bash
+$ RUST_LOG=my_lib=info cargo test
+     Running target/debug/my_lib-...
+
+running 2 tests
+test tests::it_handles_negative_numbers ... ok
+INFO:my_lib::tests: can log from the test too
+INFO:my_lib: add_one called with 2
+test tests::it_adds_one ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Note that `env_logger::init()` can only be called once, so logging can only be
+enabled for one test at a time. Additionally, the default behavior of tests to
+run in parallel means that logging output may be interleaved with test output.
+Either run tests in a single thread by specifying `RUST_TEST_THREADS=1` or by
+running one test by specifying its name as an argument to the test binaries as
+directed by the `cargo test` help docs:
+
+```bash
+$ RUST_LOG=my_lib=info cargo test it_adds_one
+     Running target/debug/my_lib-...
+
+running 1 test
+INFO:my_lib::tests: can log from the test too
+INFO:my_lib: add_one called with 2
+test tests::it_adds_one ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
+```

--- a/README.md
+++ b/README.md
@@ -108,14 +108,16 @@ mod tests {
 
     #[test]
     fn it_adds_one() {
-        env_logger::init().unwrap();
+        let _ = env_logger::init();
         info!("can log from the test too");
         assert_eq!(3, add_one(2));
     }
 
     #[test]
     fn it_handles_negative_numbers() {
-      assert_eq!(-7, add_one(-8));
+        let _ = env_logger::init();
+        info!("logging from another test");
+        assert_eq!(-7, add_one(-8));
     }
 }
 ```
@@ -128,6 +130,8 @@ $ RUST_LOG=my_lib=info cargo test
      Running target/debug/my_lib-...
 
 running 2 tests
+INFO:my_lib::tests: logging from another test
+INFO:my_lib: add_one called with -8
 test tests::it_handles_negative_numbers ... ok
 INFO:my_lib::tests: can log from the test too
 INFO:my_lib: add_one called with 2
@@ -136,8 +140,8 @@ test tests::it_adds_one ... ok
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured
 ```
 
-Note that `env_logger::init()` can only be called once, so logging can only be
-enabled for one test at a time. Additionally, the default behavior of tests to
+Note that `env_logger::init()` needs to be called in each test in which you
+want to enable logging. Additionally, the default behavior of tests to
 run in parallel means that logging output may be interleaved with test output.
 Either run tests in a single thread by specifying `RUST_TEST_THREADS=1` or by
 running one test by specifying its name as an argument to the test binaries as


### PR DESCRIPTION
This took me some trial and error to get working. 

This PR is also me asking if I'm doing this right at all... i *think* this is the best way to get log messages in tests, but I could be missing something. These make me think I'm not missing something, that this is the best way at the moment:

* https://github.com/rust-lang/log/issues/18
* https://www.reddit.com/r/rust/comments/31y66n/how_to_log_debug_in_library_tests/ctue5n0?context=10000
* http://stackoverflow.com/questions/30177845/how-to-initialize-the-logger-for-integration-tests