### PR TITLE
Port set_max_level interface from 0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,6 +682,14 @@ pub fn max_log_level() -> LogLevelFilter {
     LogLevelFilter::from_new(log::max_level())
 }
 
+/// Sets the global maximum log level.
+///
+/// Generally, this should only be called by the active logging implementation.
+#[inline(always)]
+pub fn set_max_level(level: LogLevelFilter) {
+    log::set_max_level(level.to_new())
+}
+
 /// Sets the global logger.
 ///
 /// The `make_logger` closure is passed a `MaxLogLevel` object, which the


### PR DESCRIPTION
0.4.x provides `set_max_level`, so that when logging library cannot set max level (for example, slog), logging library user can manually set it.

However In 0.3.x, `max_level` can be set only in `set_logger` interface with a `MaxLogLevelFilter` token, which forbids logging library user from setting it. This PR simply exports the `set_max_level` in 0.3.x like in 0.4.x, so that users can call it.
