### PR TITLE
kv macro support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ features = ["std", "serde", "kv_unstable_sval"]
 name = "filters"
 harness = false
 
+[[test]]
+name = "macros"
+harness = true
+
 [features]
 max_level_off   = []
 max_level_error = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1416,32 +1416,8 @@ pub fn __private_api_log(
     args: fmt::Arguments<'_>,
     level: Level,
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &str)]>,
+    kvs: Option<&[(&str, &kv::ToValue)]>,
 ) {
-    // Ideally there would be a `From` impl available for this.
-    struct KeyValues<'a> {
-        inner: &'a [(&'a str, &'a str)],
-    }
-
-    impl<'a> kv::Source for KeyValues<'a> {
-        fn visit<'kvs>(&'kvs self, visitor: &mut kv::Visitor<'kvs>) -> Result<(), kv::Error> {
-            for pair in self.inner {
-                visitor.visit_pair(pair.0.into(), pair.1.into())?;
-            }
-            Ok(())
-        }
-
-        #[inline]
-        fn count(&self) -> usize {
-            self.inner.len()
-        }
-    }
-
-    let kvs = match kvs {
-        Some(kvs) => Some(KeyValues { inner: kvs }),
-        None => None,
-    };
-
     logger().log(
         &Record::builder()
             .args(args)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1389,10 +1389,12 @@ pub fn __private_api_log(
     args: fmt::Arguments,
     level: Level,
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &str)]>
+    kvs: Option<&[(&str, &str)]>,
 ) {
     if kvs.is_some() {
-        panic!("key-value support is experimental and must be enabled using the `kv_unstable` feature")
+        panic!(
+            "key-value support is experimental and must be enabled using the `kv_unstable` feature"
+        )
     }
 
     logger().log(
@@ -1414,7 +1416,7 @@ pub fn __private_api_log(
     args: fmt::Arguments<'_>,
     level: Level,
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &str)]>
+    kvs: Option<&[(&str, &str)]>,
 ) {
     // Ideally there would be a `From` impl available for this.
     struct KeyValues<'a> {
@@ -1422,10 +1424,7 @@ pub fn __private_api_log(
     }
 
     impl<'a> kv::Source for KeyValues<'a> {
-        fn visit<'kvs>(
-            &'kvs self,
-            visitor: &mut dyn kv::Visitor<'kvs>,
-        ) -> Result<(), kv::Error> {
+        fn visit<'kvs>(&'kvs self, visitor: &mut kv::Visitor<'kvs>) -> Result<(), kv::Error> {
             for pair in self.inner {
                 visitor.visit_pair(pair.0.into(), pair.1.into())?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1389,7 +1389,12 @@ pub fn __private_api_log(
     args: fmt::Arguments,
     level: Level,
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+    kvs: Option<&[(&str, &str)]>
 ) {
+    if kvs.is_some() {
+        panic!("key-value support is experimental and must be enabled using the `kv_unstable` feature")
+    }
+
     logger().log(
         &Record::builder()
             .args(args)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1384,6 +1384,7 @@ pub fn logger() -> &'static Log {
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
 #[doc(hidden)]
+#[cfg(not(feature = "kv_unstable"))]
 pub fn __private_api_log(
     args: fmt::Arguments,
     level: Level,
@@ -1397,6 +1398,55 @@ pub fn __private_api_log(
             .module_path_static(Some(module_path))
             .file_static(Some(file))
             .line(Some(line))
+            .build(),
+    );
+}
+
+// WARNING: this is not part of the crate's public API and is subject to change at any time
+#[cfg(feature = "kv_unstable")]
+#[doc(hidden)]
+pub fn __private_api_log(
+    args: fmt::Arguments<'_>,
+    level: Level,
+    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+    kvs: Option<&[(&str, &str)]>
+) {
+    // Ideally there would be a `From` impl available for this.
+    struct KeyValues<'a> {
+        inner: &'a [(&'a str, &'a str)],
+    }
+
+    impl<'a> kv::Source for KeyValues<'a> {
+        fn visit<'kvs>(
+            &'kvs self,
+            visitor: &mut dyn kv::Visitor<'kvs>,
+        ) -> Result<(), kv::Error> {
+            for pair in self.inner {
+                visitor.visit_pair(pair.0.into(), pair.1.into())?;
+            }
+            Ok(())
+        }
+
+        #[inline]
+        fn count(&self) -> usize {
+            self.inner.len()
+        }
+    }
+
+    let kvs = match kvs {
+        Some(kvs) => Some(KeyValues { inner: kvs }),
+        None => None,
+    };
+
+    logger().log(
+        &Record::builder()
+            .args(args)
+            .level(level)
+            .target(target)
+            .module_path_static(Some(module_path))
+            .file_static(Some(file))
+            .line(Some(line))
+            .key_values(&kvs)
             .build(),
     );
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -294,3 +294,11 @@ macro_rules! __log_line {
         line!()
     };
 }
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log_stringify {
+    ($($args:tt)*) => {
+        stringify!($($args)*)
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -48,7 +48,7 @@ macro_rules! log {
 macro_rules! log_impl {
     // End of macro input
     (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {
-        let lvl = log::Level::Info;
+        let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log(
                 __log_format_args!($($arg),*),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,7 +67,7 @@ macro_rules! log_impl {
                 __log_format_args!($($arg),*),
                 lvl,
                 &(__log_module_path!(), __log_module_path!(), __log_file!(), __log_line!()),
-                Some(&[$((__log_stringify!($key), $value)),*])
+                Some(&[$((__log_stringify!($key), &$value)),*])
             );
         }
     };

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -7,7 +7,12 @@ fn kv_info() {
     info!("hello",);
     info!("hello {}", "cats");
     info!("hello {}", "cats",);
+    info!("hello {}", "cats",);
     info!("hello {}", "cats", {
+        cat_1: "chashu",
+        cat_2: "nori",
+    });
+    info!("hello {value}", value = "cats", {
         cat_1: "chashu",
         cat_2: "nori",
     });

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -15,6 +15,11 @@ fn with_args() {
 }
 
 #[test]
+fn named_arg() {
+    info!("hello {value}", value = "cats");
+}
+
+#[test]
 fn kv() {
     info!("hello {}", "cats", {
         cat_1: "chashu",
@@ -23,7 +28,7 @@ fn kv() {
 }
 
 #[test]
-fn kv_interpolated_ident_expr() {
+fn kv_and_named_arg() {
     info!("hello {value}", value = "cats", {
         cat_1: "chashu",
         cat_2: "nori",

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -2,16 +2,28 @@
 extern crate log;
 
 #[test]
-fn kv_info() {
+fn base() {
     info!("hello");
     info!("hello",);
+}
+
+#[test]
+fn with_args() {
     info!("hello {}", "cats");
     info!("hello {}", "cats",);
     info!("hello {}", "cats",);
+}
+
+#[test]
+fn kv() {
     info!("hello {}", "cats", {
         cat_1: "chashu",
         cat_2: "nori",
     });
+}
+
+#[test]
+fn kv_interpolated_ident_expr() {
     info!("hello {value}", value = "cats", {
         cat_1: "chashu",
         cat_2: "nori",

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -15,21 +15,8 @@ fn with_args() {
 }
 
 #[test]
-fn named_arg() {
-    info!("hello {value}", value = "cats");
-}
-
-#[test]
 fn kv() {
     info!("hello {}", "cats", {
-        cat_1: "chashu",
-        cat_2: "nori",
-    });
-}
-
-#[test]
-fn kv_and_named_arg() {
-    info!("hello {value}", value = "cats", {
         cat_1: "chashu",
         cat_2: "nori",
     });

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate log;
+
+#[test]
+fn kv_info() {
+    info!("hello");
+    info!("hello",);
+    info!("hello {}", "cats");
+    info!("hello {}", "cats",);
+    info!("hello {}", "cats", {
+        cat_1: "chashu",
+        cat_2: "nori",
+    });
+}


### PR DESCRIPTION
Adds key-value support to the log macros. Supersedes #346. Refs #343 #328. Thanks!

## Syntax
```rust
femme::start(log::LevelFilter::Info).unwrap();
info!("hello");
info!("hello",);
info!("hello {}", "cats");
info!("hello {}", "cats",);
info!("hello {}", "cats", {
    cat_1: "chashu",
    cat_2: "nori",
});
```


## Tasks
- [ ]  write tests