### PR TITLE
0.3.x: fix unknown path when possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,4 @@ use_std = ["log/std"]
 default = ["use_std"]
 
 [dependencies]
-log = "0.4"
-
-[patch.crates-io]
-log = { git = "https://github.com/busyjay/log", branch = "revert-to-static" }
+log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ default = ["use_std"]
 
 [dependencies]
 log = "0.4"
+
+[patch.crates-io]
+log = { git = "https://github.com/busyjay/log", branch = "revert-to-static" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -896,7 +896,7 @@ impl log::Log for LoggerAdaptor {
                     level: LogLevel::from_new(record.level()),
                     target: record.target(),
                 },
-                // file and module path aren't static in 0.4 so we can't forward them.
+                // Try best effort to forward static file and module path.
                 location: &LogLocation {
                     __file: record.file_static().unwrap_or("<unknown>"),
                     __line: record.line().unwrap_or(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,9 +898,9 @@ impl log::Log for LoggerAdaptor {
                 },
                 // file and module path aren't static in 0.4 so we can't forward them.
                 location: &LogLocation {
-                    __file: record.file().unwrap_or("<unknown>"),
+                    __file: record.file_static().unwrap_or("<unknown>"),
                     __line: record.line().unwrap_or(0),
-                    __module_path: record.module_path().unwrap_or("<unknown>"),
+                    __module_path: record.module_path_static().unwrap_or("<unknown>"),
                 },
                 args: *record.args(),
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,9 +898,9 @@ impl log::Log for LoggerAdaptor {
                 },
                 // file and module path aren't static in 0.4 so we can't forward them.
                 location: &LogLocation {
-                    __file: "<unknown>",
+                    __file: record.file().unwrap_or("<unknown>"),
                     __line: record.line().unwrap_or(0),
-                    __module_path: "<unknown>",
+                    __module_path: record.module_path().unwrap_or("<unknown>"),
                 },
                 args: *record.args(),
             };


### PR DESCRIPTION
Since 0.4..8, log can provide static string if it's available, so 0.3.x can utilize it to avoid annoying unknown string when they are using together.