### PR TITLE
Add a separate path for messages with no format arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1392,6 +1392,25 @@ pub fn __private_api_log(
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
 #[doc(hidden)]
+pub fn __private_api_log_lit(
+    message: &str,
+    level: Level,
+    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+) {
+    logger().log(
+        &Record::builder()
+            .args(format_args!("{}", message))
+            .level(level)
+            .target(target)
+            .module_path_static(Some(module_path))
+            .file_static(Some(file))
+            .line(Some(line))
+            .build(),
+    );
+}
+
+// WARNING: this is not part of the crate's public API and is subject to change at any time
+#[doc(hidden)]
 pub fn __private_api_enabled(level: Level, target: &str) -> bool {
     logger().enabled(&Metadata::builder().level(level).target(target).build())
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,6 +29,18 @@
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! log {
+    (target: $target:expr, $lvl:expr, $message:expr) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            // ensure that $message is a valid format string literal
+            let _ = __log_format_args!($message);
+            $crate::__private_api_log_lit(
+                $message,
+                lvl,
+                &($target, __log_module_path!(), __log_file!(), __log_line!()),
+            );
+        }
+    });
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,13 +47,25 @@ macro_rules! log {
 #[doc(hidden)]
 macro_rules! log_impl {
     // End of macro input
-    (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {
+    (target: $target:expr, $lvl:expr, ($message:expr)) => {
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log_lit(
+                $message,
+                lvl,
+                &($target, __log_module_path!(), __log_file!(), __log_line!()),
+            );
+        }
+    };
+
+    (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {
+        let lvl = $lvl;
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::__private_api_log(
                 __log_format_args!($($arg),*),
                 lvl,
                 &($target, __log_module_path!(), __log_file!(), __log_line!()),
+                None,
             );
         }
     };


### PR DESCRIPTION
This cuts the size of

```rust
fn main() {
    log::warn!("hello world");
}
```

from 95 bytes:

```asm
00000000000042f0 <_ZN3foo4main17h91a1e0cbbd2d1746E>:
    42f0:       48 83 ec 38             sub    $0x38,%rsp
    42f4:       48 8d 05 55 dd 02 00    lea    0x2dd55(%rip),%rax        # 32050 <_ZN3log20MAX_LOG_LEVEL_FILTER17h8b54f41fea648f5cE>
    42fb:       48 8b 00                mov    (%rax),%rax
    42fe:       48 83 f8 03             cmp    $0x3,%rax
    4302:       72 47                   jb     434b <_ZN3foo4main17h91a1e0cbbd2d1746E+0x5b>
    4304:       48 8d 05 1d bd 02 00    lea    0x2bd1d(%rip),%rax        # 30028 <anon.7cf0325160a81106a62a3eb77a18e0e0.0.llvm.16433780892884680004+0x30>
    430b:       48 89 44 24 08          mov    %rax,0x8(%rsp)
    4310:       48 c7 44 24 10 01 00    movq   $0x1,0x10(%rsp)
    4317:       00 00
    4319:       48 c7 44 24 18 00 00    movq   $0x0,0x18(%rsp)
    4320:       00 00
    4322:       48 c7 44 24 28 08 00    movq   $0x8,0x28(%rsp)
    4329:       00 00
    432b:       48 c7 44 24 30 00 00    movq   $0x0,0x30(%rsp)
    4332:       00 00
    4334:       48 8d 15 fd bc 02 00    lea    0x2bcfd(%rip),%rdx        # 30038 <anon.7cf0325160a81106a62a3eb77a18e0e0.0.llvm.16433780892884680004+0x40>
    433b:       48 8d 7c 24 08          lea    0x8(%rsp),%rdi
    4340:       be 03 00 00 00          mov    $0x3,%esi
    4345:       ff 15 0d db 02 00       callq  *0x2db0d(%rip)        # 31e58 <_GLOBAL_OFFSET_TABLE_+0x4d8>
    434b:       48 83 c4 38             add    $0x38,%rsp
    434f:       c3                      retq
```

to 45 bytes:

```asm
00000000000042f0 <_ZN3foo4main17h91a1e0cbbd2d1746E>:
    42f0:       48 8d 05 59 dd 02 00    lea    0x2dd59(%rip),%rax        # 32050 <_ZN3log20MAX_LOG_LEVEL_FILTER17h8b54f41fea648f5cE>
    42f7:       48 8b 00                mov    (%rax),%rax
    42fa:       48 83 f8 03             cmp    $0x3,%rax
    42fe:       72 1e                   jb     431e <_ZN3foo4main17h91a1e0cbbd2d1746E+0x2e>
    4300:       48 8d 3d f9 0c 02 00    lea    0x20cf9(%rip),%rdi        # 25000 <_fini+0xe44>
    4307:       48 8d 0d 1a bd 02 00    lea    0x2bd1a(%rip),%rcx        # 30028 <anon.7cf0325160a81106a62a3eb77a18e0e0.0.llvm.16433780892884680004+0x30>
    430e:       be 0b 00 00 00          mov    $0xb,%esi
    4313:       ba 03 00 00 00          mov    $0x3,%edx
    4318:       ff 25 5a d8 02 00       jmpq   *0x2d85a(%rip)        # 31b78 <_GLOBAL_OFFSET_TABLE_+0x1f8>
    431e:       c3                      retq
```

Closes #365