### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -52,7 +52,7 @@ mod std_support {
     use super::*;
     use std::{error, io};
 
-    pub(super) type BoxedError = Box<error::Error + Send + Sync>;
+    pub(super) type BoxedError = Box<dyn error::Error + Send + Sync>;
 
     impl Error {
         /// Create an error from a standard error type.

--- a/src/kv/value/internal.rs
+++ b/src/kv/value/internal.rs
@@ -12,19 +12,19 @@ pub(super) enum Inner<'v> {
     /// A simple primitive value that can be copied without allocating.
     Primitive(Primitive<'v>),
     /// A value that can be filled.
-    Fill(&'v Fill),
+    Fill(&'v dyn Fill),
     /// A debuggable value.
-    Debug(&'v fmt::Debug),
+    Debug(&'v dyn fmt::Debug),
     /// A displayable value.
-    Display(&'v fmt::Display),
+    Display(&'v dyn fmt::Display),
 
     #[cfg(feature = "kv_unstable_sval")]
     /// A structured value from `sval`.
-    Sval(&'v sval_support::Value),
+    Sval(&'v dyn sval_support::Value),
 }
 
 impl<'v> Inner<'v> {
-    pub(super) fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
+    pub(super) fn visit(&self, visitor: &mut dyn Visitor) -> Result<(), Error> {
         match *self {
             Inner::Primitive(value) => match value {
                 Primitive::Signed(value) => visitor.i64(value),
@@ -47,8 +47,8 @@ impl<'v> Inner<'v> {
 
 /// The internal serialization contract.
 pub(super) trait Visitor {
-    fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error>;
-    fn display(&mut self, v: &fmt::Display) -> Result<(), Error> {
+    fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;
+    fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
         self.debug(&format_args!("{}", v))
     }
 
@@ -61,7 +61,7 @@ pub(super) trait Visitor {
     fn none(&mut self) -> Result<(), Error>;
 
     #[cfg(feature = "kv_unstable_sval")]
-    fn sval(&mut self, v: &sval_support::Value) -> Result<(), Error>;
+    fn sval(&mut self, v: &dyn sval_support::Value) -> Result<(), Error>;
 }
 
 #[derive(Clone, Copy)]
@@ -119,7 +119,7 @@ mod fmt_support {
     struct FmtVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
 
     impl<'a, 'b: 'a> Visitor for FmtVisitor<'a, 'b> {
-        fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
+        fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
             v.fmt(self.0)?;
 
             Ok(())
@@ -154,7 +154,7 @@ mod fmt_support {
         }
 
         #[cfg(feature = "kv_unstable_sval")]
-        fn sval(&mut self, v: &sval_support::Value) -> Result<(), Error> {
+        fn sval(&mut self, v: &dyn sval_support::Value) -> Result<(), Error> {
             sval_support::fmt(self.0, v)
         }
     }
@@ -188,7 +188,7 @@ pub(super) mod sval_support {
 
     pub(in kv::value) use self::sval::Value;
 
-    pub(super) fn fmt(f: &mut fmt::Formatter, v: &sval::Value) -> Result<(), Error> {
+    pub(super) fn fmt(f: &mut fmt::Formatter, v: &dyn sval::Value) -> Result<(), Error> {
         sval::fmt::debug(f, v)?;
         Ok(())
     }
@@ -206,7 +206,7 @@ pub(super) mod sval_support {
     struct SvalVisitor<'a, 'b: 'a>(&'a mut sval::value::Stream<'b>);
 
     impl<'a, 'b: 'a> Visitor for SvalVisitor<'a, 'b> {
-        fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
+        fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
             self.0
                 .fmt(format_args!("{:?}", v))
                 .map_err(Error::from_sval)
@@ -240,7 +240,7 @@ pub(super) mod sval_support {
             self.0.none().map_err(Error::from_sval)
         }
 
-        fn sval(&mut self, v: &sval::Value) -> Result<(), Error> {
+        fn sval(&mut self, v: &dyn sval::Value) -> Result<(), Error> {
             self.0.any(v).map_err(Error::from_sval)
         }
     }

--- a/src/kv/value/mod.rs
+++ b/src/kv/value/mod.rs
@@ -55,7 +55,7 @@ where
 /// A value slot to fill using the [`Fill`](trait.Fill.html) trait.
 pub struct Slot<'a> {
     filled: bool,
-    visitor: &'a mut Visitor,
+    visitor: &'a mut dyn Visitor,
 }
 
 impl<'a> fmt::Debug for Slot<'a> {
@@ -65,7 +65,7 @@ impl<'a> fmt::Debug for Slot<'a> {
 }
 
 impl<'a> Slot<'a> {
-    fn new(visitor: &'a mut Visitor) -> Self {
+    fn new(visitor: &'a mut dyn Visitor) -> Self {
         Slot {
             visitor,
             filled: false,
@@ -110,7 +110,7 @@ impl<'v> Value<'v> {
         }
     }
 
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
+    fn visit(&self, visitor: &mut dyn Visitor) -> Result<(), Error> {
         self.inner.visit(visitor)
     }
 }
@@ -125,7 +125,7 @@ mod tests {
 
         impl Fill for TestFill {
             fn fill(&self, slot: &mut Slot) -> Result<(), Error> {
-                let dbg: &fmt::Debug = &1;
+                let dbg: &dyn fmt::Debug = &1;
 
                 slot.fill(Value::from_debug(&dbg))
             }

--- a/src/kv/value/test.rs
+++ b/src/kv/value/test.rs
@@ -26,7 +26,7 @@ impl<'v> Value<'v> {
         struct TestVisitor(Option<Token>);
 
         impl internal::Visitor for TestVisitor {
-            fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
+            fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 self.0 = Some(Token::Str(format!("{:?}", v)));
                 Ok(())
             }
@@ -67,7 +67,7 @@ impl<'v> Value<'v> {
             }
 
             #[cfg(feature = "kv_unstable_sval")]
-            fn sval(&mut self, _: &internal::sval_support::Value) -> Result<(), Error> {
+            fn sval(&mut self, _: &dyn internal::sval_support::Value) -> Result<(), Error> {
                 self.0 = Some(Token::Sval);
                 Ok(())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ pub mod kv;
 
 // The LOGGER static holds a pointer to the global logger. It is protected by
 // the STATE static which determines whether LOGGER has been initialized yet.
-static mut LOGGER: &'static dyn Log = &NopLogger;
+static mut LOGGER: &dyn Log = &NopLogger;
 
 #[allow(deprecated)]
 static STATE: AtomicUsize = ATOMIC_USIZE_INIT;
@@ -320,11 +320,11 @@ const INITIALIZED: usize = 2;
 #[allow(deprecated)]
 static MAX_LOG_LEVEL_FILTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
-static LOG_LEVEL_NAMES: [&'static str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
-static SET_LOGGER_ERROR: &'static str = "attempted to set a logger after the logging system \
-                                         was already initialized";
-static LEVEL_PARSE_ERROR: &'static str =
+static SET_LOGGER_ERROR: &str = "attempted to set a logger after the logging system \
+                                 was already initialized";
+static LEVEL_PARSE_ERROR: &str =
     "attempted to convert a string that doesn't match an existing log level";
 
 /// An enum representing the available verbosity levels of the logger.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1199,7 +1199,7 @@ pub fn max_level() -> LevelFilter {
 /// [`set_logger`]: fn.set_logger.html
 #[cfg(all(feature = "std", atomic_cas))]
 pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
-    set_logger_inner(|| unsafe { &*Box::into_raw(logger) })
+    set_logger_inner(|| Box::leak(logger))
 }
 
 /// Sets the global logger to a `&'static Log`.

--- a/test_max_level_features/main.rs
+++ b/test_max_level_features/main.rs
@@ -8,9 +8,7 @@ use log::{Level, LevelFilter, Log, Record, Metadata};
 use log::set_boxed_logger;
 #[cfg(not(feature = "std"))]
 fn set_boxed_logger(logger: Box<Log>) -> Result<(), log::SetLoggerError> {
-    unsafe {
-        log::set_logger(&*Box::into_raw(logger))
-    }
+    log::set_logger(Box::leak(logger))
 }
 
 struct State {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use log::set_boxed_logger;
 
 #[cfg(not(feature = "std"))]
-fn set_boxed_logger(logger: Box<Log>) -> Result<(), log::SetLoggerError> {
+fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
     log::set_logger(Box::leak(logger))
 }
 

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -9,7 +9,7 @@ use log::set_boxed_logger;
 
 #[cfg(not(feature = "std"))]
 fn set_boxed_logger(logger: Box<Log>) -> Result<(), log::SetLoggerError> {
-    log::set_logger(unsafe { &*Box::into_raw(logger) })
+    log::set_logger(Box::leak(logger))
 }
 
 struct State {


### PR DESCRIPTION
Since the minimum supported rustc version was bumped in #362, it is now possible to do some cleanup.

* Get rid of a re-implementation of `Box::leak`. This reduces the number of unsafe blocks to 4.
* Run `cargo fix` to add the `dyn` keyword to a lot of types.
* Remove a few instances of the `'static` lifetime in some static items.