### PR TITLE
Prepare for 0.4.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ version using log 0.4.x to avoid losing module and file information.
 Look at the [release tags] for information about older releases.
 
 [Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.8...HEAD
+[0.4.9]: https://github.com/rust-lang-nursery/log/compare/0.4.8...0.4.9
 [0.4.8]: https://github.com/rust-lang-nursery/log/compare/0.4.7...0.4.8
 [0.4.7]: https://github.com/rust-lang-nursery/log/compare/0.4.6...0.4.7
 [0.4.6]: https://github.com/rust-lang-nursery/log/compare/0.4.5...0.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.4.9] - 2019-12-12
+
+### Minimum Supported Rust Version
+
+This release bumps the minimum compiler version to `1.31.0`. This was mainly needed for `cfg-if`,
+but between `1.16.0` and `1.31.0` there are a lot of language and library improvements we now
+take advantage of.
+
+### New
+
+* Unstable support for capturing key-value pairs in a record using the `log!` macros
+
+### Improved
+
+* Better documentation for max level filters.
+* Internal updates to line up with bumped MSRV
+
 ## [0.4.8] - 2019-07-28
 
 ### New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.8" # remember to update html_root_url
+version = "0.4.9" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.8"
+    html_root_url = "https://docs.rs/log/0.4.9"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
[Changeset since the last release](https://github.com/rust-lang/log/compare/0.4.8...master)

**Minimum supported `rustc` is being bumped to `1.31.0`.** This release is just over 12 months old now.

Includes:

- #347
- #349 
- #352
- #354
- #362
- #353
- #366
- #367

This release includes some macro support for our experimental structured logging, which could use some more eyes to make sure we're not missing anything important.

cc @wycats 

r? @sfackler @dtolnay @BurntSushi 