### PR TITLE
fix up macro use in expr context

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,7 @@ macro_rules! log {
 #[doc(hidden)]
 macro_rules! log_impl {
     // End of macro input
-    (target: $target:expr, $lvl:expr, ($message:expr)) => {
+    (target: $target:expr, $lvl:expr, ($message:expr)) => {{
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log_lit(
@@ -56,9 +56,8 @@ macro_rules! log_impl {
                 &($target, __log_module_path!(), __log_file!(), __log_line!()),
             );
         }
-    };
-
-    (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {
+    }};
+    (target: $target:expr, $lvl:expr, ($($arg:expr),*)) => {{
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log(
@@ -68,10 +67,10 @@ macro_rules! log_impl {
                 None,
             );
         }
-    };
+    }};
 
     // // Trailing k-v pairs containing no trailing comma
-    (target: $target:expr, $lvl:expr, ($($arg:expr),*) { $($key:ident : $value:expr),* }) => {
+    (target: $target:expr, $lvl:expr, ($($arg:expr),*) { $($key:ident : $value:expr),* }) => {{
         let lvl = log::Level::Info;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log(
@@ -81,7 +80,7 @@ macro_rules! log_impl {
                 Some(&[$((__log_stringify!($key), &$value)),*])
             );
         }
-    };
+    }};
 
     // Trailing k-v pairs with trailing comma
     (target: $target:expr, $lvl:expr, ($($e:expr),*) { $($key:ident : $value:expr,)* }) => {

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -8,10 +8,22 @@ fn base() {
 }
 
 #[test]
+fn base_expr_context() {
+    let _ = info!("hello");
+}
+
+#[test]
 fn with_args() {
     info!("hello {}", "cats");
     info!("hello {}", "cats",);
     info!("hello {}", "cats",);
+}
+
+#[test]
+fn with_args_expr_context() {
+    match "cats" {
+        cats => info!("hello {}", cats),
+    };
 }
 
 #[test]
@@ -20,4 +32,14 @@ fn kv() {
         cat_1: "chashu",
         cat_2: "nori",
     });
+}
+
+#[test]
+fn kv_expr_context() {
+    match "chashu" {
+        cat_1 => info!("hello {}", "cats", {
+            cat_1: cat_1,
+            cat_2: "nori",
+        }),
+    };
 }


### PR DESCRIPTION
Fixes #369

Also adds some test coverage for `log!` macros in expression context, which regressed between `0.4.8` and `0.4.9`.

r? @sfackler 