### PR TITLE
Prepare for 0.4.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.4.10] - 2019-12-16
+
+### Fixed
+
+* Fixed the `log!` macros so they work in expression context (this regressed in `0.4.9`, which has been yanked).
+
 ## [0.4.9] - 2019-12-12
 
 ### Minimum Supported Rust Version
@@ -149,7 +155,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.8...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.10...HEAD
+[0.4.10]: https://github.com/rust-lang-nursery/log/compare/0.4.9...0.4.10
 [0.4.9]: https://github.com/rust-lang-nursery/log/compare/0.4.8...0.4.9
 [0.4.8]: https://github.com/rust-lang-nursery/log/compare/0.4.7...0.4.8
 [0.4.7]: https://github.com/rust-lang-nursery/log/compare/0.4.6...0.4.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.9" # remember to update html_root_url
+version = "0.4.10" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.9"
+    html_root_url = "https://docs.rs/log/0.4.10"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,17 +30,19 @@
 #[macro_export(local_inner_macros)]
 macro_rules! log {
     // log!(target: "...", "...")
-    (target: $target:expr, $lvl:expr, $e:expr) => {
+    (target: $target:expr, $lvl:expr, $e:expr) => (
         $crate::log_impl!(target: $target, $lvl, ($e));
-    };
+    );
 
     // log!(target: "...", "...", args...)
-    (target: $target:expr, $lvl:expr, $e:expr, $($rest:tt)*) => {
+    (target: $target:expr, $lvl:expr, $e:expr, $($rest:tt)*) => (
         $crate::log_impl!(target: $target, $lvl, ($e) $($rest)*);
-    };
+    );
 
     // log!("...", args...)
-    ($lvl:expr, $($arg:tt)+) => ($crate::log!(target: __log_module_path!(), $lvl, $($arg)+))
+    ($lvl:expr, $($arg:tt)+) => (
+        $crate::log!(target: __log_module_path!(), $lvl, $($arg)+);
+    )
 }
 
 #[macro_export(local_inner_macros)]
@@ -83,19 +85,19 @@ macro_rules! log_impl {
     }};
 
     // Trailing k-v pairs with trailing comma
-    (target: $target:expr, $lvl:expr, ($($e:expr),*) { $($key:ident : $value:expr,)* }) => {
+    (target: $target:expr, $lvl:expr, ($($e:expr),*) { $($key:ident : $value:expr,)* }) => (
         $crate::log_impl!(target: $target, $lvl, ($($e),*) { $($key : $value),* });
-    };
+    );
 
     // Last expression arg with no trailing comma
-    (target: $target:expr, $lvl:expr, ($($e:expr),*) $arg:expr) => {
+    (target: $target:expr, $lvl:expr, ($($e:expr),*) $arg:expr) => (
         $crate::log_impl!(target: $target, $lvl, ($($e,)* $arg));
-    };
+    );
 
     // Expression arg
-    (target: $target:expr, $lvl:expr, ($($e:expr),*) $arg:expr, $($rest:tt)*) => {
+    (target: $target:expr, $lvl:expr, ($($e:expr),*) $arg:expr, $($rest:tt)*) => (
         $crate::log_impl!(target: $target, $lvl, ($($e,)* $arg) $($rest)*);
-    };
+    )
 }
 
 /// Logs a message at the error level.


### PR DESCRIPTION
Includes #370 

I've also just made our macro syntax consistent so we can see matches that are terminal vs matches that just expand to other matches.

r? @sfackler