### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -66,11 +66,7 @@ mod std_support {
         }
     }
 
-    impl error::Error for Error {
-        fn description(&self) -> &str {
-            "key values error"
-        }
-    }
+    impl error::Error for Error {}
 
     impl From<io::Error> for Error {
         fn from(err: io::Error) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,11 +1330,7 @@ impl fmt::Display for SetLoggerError {
 
 // The Error trait is not available in libcore
 #[cfg(feature = "std")]
-impl error::Error for SetLoggerError {
-    fn description(&self) -> &str {
-        SET_LOGGER_ERROR
-    }
-}
+impl error::Error for SetLoggerError {}
 
 /// The type returned by [`from_str`] when the string doesn't match any of the log levels.
 ///
@@ -1351,11 +1347,7 @@ impl fmt::Display for ParseLevelError {
 
 // The Error trait is not available in libcore
 #[cfg(feature = "std")]
-impl error::Error for ParseLevelError {
-    fn description(&self) -> &str {
-        LEVEL_PARSE_ERROR
-    }
-}
+impl error::Error for ParseLevelError {}
 
 /// Returns a reference to the logger.
 ///
@@ -1579,7 +1571,7 @@ mod tests {
         use std::error::Error;
         let e = SetLoggerError(());
         assert_eq!(
-            e.description(),
+            &e.to_string(),
             "attempted to set a logger after the logging system \
              was already initialized"
         );


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes all implementations of `description` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919