### PR TITLE
Revert the macro implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1365,39 +1365,10 @@ pub fn logger() -> &'static dyn Log {
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
 #[doc(hidden)]
-#[cfg(not(feature = "kv_unstable"))]
 pub fn __private_api_log(
     args: fmt::Arguments,
     level: Level,
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &str)]>,
-) {
-    if kvs.is_some() {
-        panic!(
-            "key-value support is experimental and must be enabled using the `kv_unstable` feature"
-        )
-    }
-
-    logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .build(),
-    );
-}
-
-// WARNING: this is not part of the crate's public API and is subject to change at any time
-#[cfg(feature = "kv_unstable")]
-#[doc(hidden)]
-pub fn __private_api_log(
-    args: fmt::Arguments<'_>,
-    level: Level,
-    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &dyn kv::ToValue)]>,
 ) {
     logger().log(
         &Record::builder()
@@ -1407,7 +1378,6 @@ pub fn __private_api_log(
             .module_path_static(Some(module_path))
             .file_static(Some(file))
             .line(Some(line))
-            .key_values(&kvs)
             .build(),
     );
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -34,21 +34,3 @@ fn with_named_args() {
     info!("hello {cats}", cats = cats,);
     info!("hello {cats}", cats = cats,);
 }
-
-#[test]
-fn kv() {
-    info!("hello {}", "cats", {
-        cat_1: "chashu",
-        cat_2: "nori",
-    });
-}
-
-#[test]
-fn kv_expr_context() {
-    match "chashu" {
-        cat_1 => info!("hello {}", "cats", {
-            cat_1: cat_1,
-            cat_2: "nori",
-        }),
-    };
-}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -27,6 +27,15 @@ fn with_args_expr_context() {
 }
 
 #[test]
+fn with_named_args() {
+    let cats = "cats";
+
+    info!("hello {cats}", cats = cats);
+    info!("hello {cats}", cats = cats,);
+    info!("hello {cats}", cats = cats,);
+}
+
+#[test]
 fn kv() {
     info!("hello {}", "cats", {
         cat_1: "chashu",


### PR DESCRIPTION
In #369 and #372 we've run into a few regressions with the new macro implementation that supports key-value pairs. This PR shifts that implementation onto a new branch called [`kv_macro`](https://github.com/rust-lang/log/tree/kv_macro) so that we can work on it out-of-band.

cc @yoshuawuyts

r? @sfackler 