### PR TITLE
Show master branch build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ log
 
 A Rust library providing a lightweight logging *facade*.
 
+[![Build status](https://img.shields.io/github/workflow/status/rust-lang/log/CI/master)](https://github.com/rust-lang/log/actions)
 [![Latest version](https://img.shields.io/crates/v/log.svg)](https://crates.io/crates/log)
 [![Documentation](https://docs.rs/log/badge.svg)](https://docs.rs/log)
 ![License](https://img.shields.io/crates/l/log.svg)


### PR DESCRIPTION
The current crate description on crates.io shows a failing build (pointed at `alexcrichton/log` on AppVeyor); checking back here to the README I couldn't easily see where builds are happening now, hence this PR. HTH!