### PR TITLE
Document use of mem::transmute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,10 @@ pub enum Level {
     /// The "error" level.
     ///
     /// Designates very serious errors.
-    Error = 1, // This way these line up with the discriminants for LevelFilter below
+    // This way these line up with the discriminants for LevelFilter below
+    // This works because Rust treats field-less enums the same way as C does:
+    // https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-field-less-enumerations
+    Error = 1,
     /// The "warn" level.
     ///
     /// Designates hazardous situations.
@@ -1173,6 +1176,12 @@ pub fn set_max_level(level: LevelFilter) {
 /// [`set_max_level`]: fn.set_max_level.html
 #[inline(always)]
 pub fn max_level() -> LevelFilter {
+    // Since `LevelFilter` is `repr(usize)`,
+    // this transmute is sound if and only if `MAX_LOG_LEVEL_FILTER`
+    // is set to a usize that is a valid discriminant for `LevelFilter`.
+    // Since `MAX_LOG_LEVEL_FILTER` is private, the only time it's set
+    // is by `set_max_level` above, i.e. by casting a `LevelFilter` to `usize`.
+    // So any usize stored in `MAX_LOG_LEVEL_FILTER` is a valid discriminant.
     unsafe { mem::transmute(MAX_LOG_LEVEL_FILTER.load(Ordering::Relaxed)) }
 }
 


### PR DESCRIPTION
This removes the `mem::transmute` in `max_level` in favor of an explicit match.

Previously, the `LevelFilter` had `#[repr(usize)]`. `set_max_level` would call `level as usize` and `max_level` would use `transmute::<usize, LevelFilter>`. This does not seem to be defined behavior - although `repr(usize)` [guarantees that `LevelFilter` will be represented as a `usize`](https://doc.rust-lang.org/nomicon/other-reprs.html#repru-repri), it does not guarantee that every `usize` is a valid `LevelFilter`.

Furthermore, although in practice `as usize` will return 0, 1, ... for the enum variants, this is not guaranteed by the compiler, even though [other parts of the code depend on this](https://github.com/rust-lang/log/compare/master...jyn514:master#diff-b4aea3e418ccdb71239b96952d9cddb6L334).

This explicitly specifies the discriminant values for `LevelFilter` and changes `max_level` to use `LevelFilter::from_usize` instead of `transmute`. Additionally, this reduces the scope of a few `unsafe` blocks (I can remove this if you like).

cc @Shnatsel