### PR TITLE
Add reference to win_dbg_logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ There are many available implementations to chose from, here are some of the mos
     * [`syslog`](https://docs.rs/syslog/*/syslog/)
     * [`slog-stdlog`](https://docs.rs/slog-stdlog/*/slog_stdlog/)
     * [`android_log`](https://docs.rs/android_log/*/android_log/)
+    * [`win_dbg_logger`](https://docs.rs/win_dbg_logger/*/win_dbg_logger/)
 * For WebAssembly binaries:
     * [`console_log`](https://docs.rs/console_log/*/console_log/)
 


### PR DESCRIPTION
win_dbg_logger is logger for use with Windows debuggers.

Windows allows applications to output a string directly to debuggers. This is
very useful in situations where other forms of logging are not available.
For example, stderr is not available for GUI apps.

This crate can be compiled and used on non-Windows platforms, but it does
nothing. This is intended to minimize the impact on code that takes a
dependency on this crate.