### PR TITLE
Avoid format_args expansion when logging is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ harness = false
 name = "macros"
 harness = true
 
+[[test]]
+name = "expansion"
+harness = false
+
 [features]
 max_level_off   = []
 max_level_error = []

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,8 +30,9 @@
 #[macro_export(local_inner_macros)]
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $message:expr) => ({
+        let target = $target;
         let lvl = $lvl;
-        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+        if log_enabled!(target: target, lvl) {
             // ensure that $message is a valid format string literal
             let _ = __log_format_args!($message);
             $crate::__private_api_log_lit(
@@ -42,12 +43,13 @@ macro_rules! log {
         }
     });
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        let target = $target;
         let lvl = $lvl;
-        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+        if log_enabled!(target: target, lvl) {
             $crate::__private_api_log(
                 __log_format_args!($($arg)+),
                 lvl,
-                &($target, __log_module_path!(), __log_file!(), __log_line!()),
+                &(target, __log_module_path!(), __log_file!(), __log_line!()),
             );
         }
     });

--- a/tests/expansion.rs
+++ b/tests/expansion.rs
@@ -1,0 +1,46 @@
+#[macro_use]
+extern crate log;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+#[cfg(feature = "std")]
+use log::set_boxed_logger;
+
+#[cfg(not(feature = "std"))]
+fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
+    log::set_logger(Box::leak(logger))
+}
+
+struct SimpleLogger;
+
+impl Log for SimpleLogger {
+    fn enabled(&self, m: &Metadata) -> bool {
+        m.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let _ = format!("{}", record.args());
+        }
+    }
+    fn flush(&self) {}
+}
+
+static mut COUNT: usize = 0;
+fn expand(msg: &str) -> &str {
+    unsafe { COUNT += 1 };
+    msg
+}
+
+fn main() {
+    set_boxed_logger(Box::new(SimpleLogger)).unwrap();
+    log::set_max_level(LevelFilter::Trace);
+
+    unsafe { COUNT = 0 };
+    trace!("expand: {}", expand("expanded"));
+    assert_eq!(unsafe { COUNT }, 0);
+
+    unsafe { COUNT = 0 };
+    warn!("expand: {}", expand("expanded"));
+    assert_eq!(unsafe { COUNT }, 1);
+}


### PR DESCRIPTION
Revisit of https://github.com/rust-lang/log/pull/297/files.

That PR got the following comments: 

> Wouldn't the removal of if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() cause the build time removal of the log entries over a specific level to stop to work?

and 

> This imposes a nontrivial cost to all log events that don't have expensive arguments. Older versions of the log crate looked like this and we explicitly moved away from it under the idea that we should optimize for the common case of cheap arguments.

Though, it seems that currently even if a log is to be filtered out by the logger, the entire log message is constructed and allocated. Which doesn't seem "optimized for cheap arguments".

Also, I don't know about compiler internals, but the difference is that this check
```rust
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() { 
```
is turned into this check
```rust
        lvl <= $crate::STATIC_MAX_LEVEL
            && lvl <= $crate::max_level()
            && $crate::__private_api_enabled(lvl, $target)
```
I think if the compiler can compile away code behind `if false {`, I suppose it can also compile away code behind `if false && ... {`, no?

The test provided currently fails as the argument is also expanded when the message is not logged.