### PR TITLE
Resolve possible inference disruption by removing unneeded From impl

### DIFF
--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -41,12 +41,6 @@ impl From<fmt::Error> for Error {
     }
 }
 
-impl From<Error> for fmt::Error {
-    fn from(_: Error) -> Self {
-        fmt::Error
-    }
-}
-
 #[cfg(feature = "std")]
 mod std_support {
     use super::*;

--- a/src/kv/value/internal/fmt.rs
+++ b/src/kv/value/internal/fmt.rs
@@ -65,7 +65,7 @@ pub(in kv::value) use self::fmt::{Arguments, Debug, Display};
 
 impl<'v> fmt::Debug for kv::Value<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.visit(&mut FmtVisitor(f))?;
+        self.visit(&mut FmtVisitor(f)).map_err(|_| fmt::Error)?;
 
         Ok(())
     }
@@ -73,7 +73,7 @@ impl<'v> fmt::Debug for kv::Value<'v> {
 
 impl<'v> fmt::Display for kv::Value<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.visit(&mut FmtVisitor(f))?;
+        self.visit(&mut FmtVisitor(f)).map_err(|_| fmt::Error)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,7 +747,7 @@ struct KeyValues<'a>(&'a dyn kv::Source);
 impl<'a> fmt::Debug for KeyValues<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut visitor = f.debug_map();
-        self.0.visit(&mut visitor)?;
+        self.0.visit(&mut visitor).map_err(|_| fmt::Error)?;
         visitor.finish()
     }
 }


### PR DESCRIPTION
This impl breaks some code in rust-analyzer's ra_hir_def crate.

https://github.com/rust-analyzer/rust-analyzer/blob/1dba84019e0f3e7175f204624629a52013332e52/crates/ra_hir_def/src/path.rs#L273-L307

```console
$ cargo check --manifest-path crates/ra_hir_def/Cargo.toml
    Checking ra_hir_def v0.1.0
    Finished dev [unoptimized] target(s) in 0.75s

$ cargo check --manifest-path crates/ra_hir_def/Cargo.toml --features log/kv_unstable
    Checking ra_hir_def v0.1.0
error[E0282]: type annotations needed for the closure `fn(&str) -> std::result::Result<(), _>`
   --> crates/ra_hir_def/src/path.rs:278:17
    |
278 |                 f.write_str("::")?;
    |                 ^^^^^^^^^^^^^^^^^^ cannot infer type
    |
help: give this closure an explicit return type without `_` placeholders
    |
276 |         let mut add_segment = |s| -> std::result::Result<(), _> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Closes https://github.com/rust-lang/log/issues/397.