### PR TITLE
Respect fmt trait and flags in Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ kv_unstable_sval = ["kv_unstable", "sval/fmt"]
 [dependencies]
 cfg-if = "0.1.2"
 serde = { version = "1.0", optional = true, default-features = false }
-sval = { version = "0.5", optional = true, default-features = false }
+sval = { version = "0.5.2", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"
-sval = { version = "0.5", features = ["test"] }
+sval = { version = "0.5.2", features = ["test"] }

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -67,10 +67,4 @@ mod std_support {
             Error::boxed(err)
         }
     }
-
-    impl From<Error> for io::Error {
-        fn from(err: Error) -> Self {
-            io::Error::new(io::ErrorKind::Other, err)
-        }
-    }
 }

--- a/src/kv/value/fill.rs
+++ b/src/kv/value/fill.rs
@@ -145,4 +145,20 @@ mod tests {
                 .expect("invalid value")
         );
     }
+
+    #[test]
+    fn fill_debug() {
+        struct TestFill;
+
+        impl Fill for TestFill {
+            fn fill(&self, slot: &mut Slot) -> Result<(), Error> {
+                slot.fill_any(42u64)
+            }
+        }
+
+        assert_eq!(
+            format!("{:04?}", 42u64),
+            format!("{:04?}", Value::from_fill(&TestFill)),
+        )
+    }
 }

--- a/src/kv/value/impls.rs
+++ b/src/kv/value/impls.rs
@@ -131,10 +131,7 @@ mod tests {
             format_args!("a {}", "value").to_value().to_string(),
             "a value"
         );
-        assert_eq!(
-            "a loong string".to_value().to_string(),
-            "a loong string"
-        );
+        assert_eq!("a loong string".to_value().to_string(), "a loong string");
         assert_eq!(Some(true).to_value().to_string(), "true");
         assert_eq!(().to_value().to_string(), "None");
         assert_eq!(Option::None::<bool>.to_value().to_string(), "None");

--- a/src/kv/value/impls.rs
+++ b/src/kv/value/impls.rs
@@ -126,14 +126,14 @@ mod tests {
         assert_eq!(42i64.to_value().to_string(), "42");
         assert_eq!(42.01f64.to_value().to_string(), "42.01");
         assert_eq!(true.to_value().to_string(), "true");
-        assert_eq!('a'.to_value().to_string(), "'a'");
+        assert_eq!('a'.to_value().to_string(), "a");
         assert_eq!(
             format_args!("a {}", "value").to_value().to_string(),
             "a value"
         );
         assert_eq!(
             "a loong string".to_value().to_string(),
-            "\"a loong string\""
+            "a loong string"
         );
         assert_eq!(Some(true).to_value().to_string(), "true");
         assert_eq!(().to_value().to_string(), "None");

--- a/src/kv/value/internal/fmt.rs
+++ b/src/kv/value/internal/fmt.rs
@@ -244,9 +244,6 @@ mod tests {
             format!("{}", "a string".to_value()),
         );
 
-        assert_eq!(
-            format!("{:04}", 42u64),
-            format!("{:04}", 42u64.to_value()),
-        );
+        assert_eq!(format!("{:04}", 42u64), format!("{:04}", 42u64.to_value()),);
     }
 }

--- a/src/kv/value/internal/fmt.rs
+++ b/src/kv/value/internal/fmt.rs
@@ -65,7 +65,68 @@ pub(in kv::value) use self::fmt::{Arguments, Debug, Display};
 
 impl<'v> fmt::Debug for kv::Value<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.visit(&mut FmtVisitor(f)).map_err(|_| fmt::Error)?;
+        struct DebugVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
+
+        impl<'a, 'b: 'a, 'v> Visitor<'v> for DebugVisitor<'a, 'b> {
+            fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
+                fmt::Debug::fmt(v, self.0)?;
+
+                Ok(())
+            }
+
+            fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
+                fmt::Display::fmt(v, self.0)?;
+
+                Ok(())
+            }
+
+            fn u64(&mut self, v: u64) -> Result<(), Error> {
+                fmt::Debug::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn i64(&mut self, v: i64) -> Result<(), Error> {
+                fmt::Debug::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn f64(&mut self, v: f64) -> Result<(), Error> {
+                fmt::Debug::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn bool(&mut self, v: bool) -> Result<(), Error> {
+                fmt::Debug::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn char(&mut self, v: char) -> Result<(), Error> {
+                fmt::Debug::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn str(&mut self, v: &str) -> Result<(), Error> {
+                fmt::Debug::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn none(&mut self) -> Result<(), Error> {
+                self.debug(&format_args!("None"))
+            }
+
+            #[cfg(feature = "kv_unstable_sval")]
+            fn sval(&mut self, v: &dyn super::sval::Value) -> Result<(), Error> {
+                super::sval::fmt(self.0, v)
+            }
+        }
+
+        self.visit(&mut DebugVisitor(f)).map_err(|_| fmt::Error)?;
 
         Ok(())
     }
@@ -73,58 +134,78 @@ impl<'v> fmt::Debug for kv::Value<'v> {
 
 impl<'v> fmt::Display for kv::Value<'v> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.visit(&mut FmtVisitor(f)).map_err(|_| fmt::Error)?;
+        struct DisplayVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
+
+        impl<'a, 'b: 'a, 'v> Visitor<'v> for DisplayVisitor<'a, 'b> {
+            fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
+                fmt::Debug::fmt(v, self.0)?;
+
+                Ok(())
+            }
+
+            fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
+                fmt::Display::fmt(v, self.0)?;
+
+                Ok(())
+            }
+
+            fn u64(&mut self, v: u64) -> Result<(), Error> {
+                fmt::Display::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn i64(&mut self, v: i64) -> Result<(), Error> {
+                fmt::Display::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn f64(&mut self, v: f64) -> Result<(), Error> {
+                fmt::Display::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn bool(&mut self, v: bool) -> Result<(), Error> {
+                fmt::Display::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn char(&mut self, v: char) -> Result<(), Error> {
+                fmt::Display::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn str(&mut self, v: &str) -> Result<(), Error> {
+                fmt::Display::fmt(&v, self.0)?;
+
+                Ok(())
+            }
+
+            fn none(&mut self) -> Result<(), Error> {
+                self.debug(&format_args!("None"))
+            }
+
+            #[cfg(feature = "kv_unstable_sval")]
+            fn sval(&mut self, v: &dyn super::sval::Value) -> Result<(), Error> {
+                super::sval::fmt(self.0, v)
+            }
+        }
+
+        self.visit(&mut DisplayVisitor(f)).map_err(|_| fmt::Error)?;
 
         Ok(())
-    }
-}
-
-struct FmtVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
-
-impl<'a, 'b: 'a, 'v> Visitor<'v> for FmtVisitor<'a, 'b> {
-    fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
-        v.fmt(self.0)?;
-
-        Ok(())
-    }
-
-    fn u64(&mut self, v: u64) -> Result<(), Error> {
-        self.debug(&format_args!("{:?}", v))
-    }
-
-    fn i64(&mut self, v: i64) -> Result<(), Error> {
-        self.debug(&format_args!("{:?}", v))
-    }
-
-    fn f64(&mut self, v: f64) -> Result<(), Error> {
-        self.debug(&format_args!("{:?}", v))
-    }
-
-    fn bool(&mut self, v: bool) -> Result<(), Error> {
-        self.debug(&format_args!("{:?}", v))
-    }
-
-    fn char(&mut self, v: char) -> Result<(), Error> {
-        self.debug(&format_args!("{:?}", v))
-    }
-
-    fn str(&mut self, v: &str) -> Result<(), Error> {
-        self.debug(&format_args!("{:?}", v))
-    }
-
-    fn none(&mut self) -> Result<(), Error> {
-        self.debug(&format_args!("None"))
-    }
-
-    #[cfg(feature = "kv_unstable_sval")]
-    fn sval(&mut self, v: &dyn super::sval::Value) -> Result<(), Error> {
-        super::sval::fmt(self.0, v)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::kv::value::ToValue;
 
     #[test]
     fn fmt_cast() {
@@ -140,6 +221,32 @@ mod tests {
             kv::Value::from_display(&"a string")
                 .to_borrowed_str()
                 .expect("invalid value")
+        );
+    }
+
+    #[test]
+    fn fmt_debug() {
+        assert_eq!(
+            format!("{:?}", "a string"),
+            format!("{:?}", "a string".to_value()),
+        );
+
+        assert_eq!(
+            format!("{:04?}", 42u64),
+            format!("{:04?}", 42u64.to_value()),
+        );
+    }
+
+    #[test]
+    fn fmt_display() {
+        assert_eq!(
+            format!("{}", "a string"),
+            format!("{}", "a string".to_value()),
+        );
+
+        assert_eq!(
+            format!("{:04}", 42u64),
+            format!("{:04}", 42u64.to_value()),
         );
     }
 }


### PR DESCRIPTION
Fixes #395 

This PR makes the `fmt::Debug` and `fmt::Display` impls on `Value` respect the trait being used and any flags present. I've added a separate visitor for `Display` that uses the right trait, and pass the value directly to the formatter instead of going through `format_args`.

There are some extra tests for formatting and I've shifted a few pieces around to be consistent. ~~Tests won't pass until I fix https://github.com/sval-rs/sval/issues/84 as well.~~

r? @yoshuawuyts 