### PR TITLE
Prepare for 0.4.11 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
       run: |
-        rustup update ${{ matrix.rust }}
+        rustup update ${{ matrix.rust }} --no-self-update
         rustup default ${{ matrix.rust }}
     - run: cargo test --verbose
     - run: cargo test --verbose --features serde
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: |
-        rustup update stable
+        rustup update stable --no-self-update
         rustup default stable
         rustup component add rustfmt
     - run: cargo fmt -- --check
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Install Rust
         run: |
-          rustup update 1.31.0
+          rustup update 1.31.0 --no-self-update
           rustup default 1.31.0
       - run: cargo build --verbose
       - run: cargo build --verbose --features serde
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Install Rust
         run: |
-          rustup update stable
+          rustup update stable --no-self-update
           rustup default stable
       - run: rustup target add thumbv6m-none-eabi
       - run: cargo build --verbose --target=thumbv6m-none-eabi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,28 @@
 
 ## [Unreleased]
 
-## [0.4.10] - 2019-12-16
+## [0.4.11] - 2020-07-09
+
+### New
+
+* Support coercing structured values into concrete types.
+* Reference the `win_dbg_logger` in the readme.
+
+### Fixed
+
+* Updates a few deprecated items used internally.
+* Fixed issues in docs and expands sections.
+* Show the correct build badge in the readme.
+* Fix up a possible inference breakage with structured value errors.
+* Respect formatting flags in structured value formatting.
+
+## [0.4.10] - 2019-12-16 (yanked)
 
 ### Fixed
 
 * Fixed the `log!` macros so they work in expression context (this regressed in `0.4.9`, which has been yanked).
 
-## [0.4.9] - 2019-12-12
+## [0.4.9] - 2019-12-12 (yanked)
 
 ### Minimum Supported Rust Version
 
@@ -155,7 +170,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.10...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.11...HEAD
+[0.4.11]: https://github.com/rust-lang-nursery/log/compare/0.4.10...0.4.11
 [0.4.10]: https://github.com/rust-lang-nursery/log/compare/0.4.9...0.4.10
 [0.4.9]: https://github.com/rust-lang-nursery/log/compare/0.4.8...0.4.9
 [0.4.8]: https://github.com/rust-lang-nursery/log/compare/0.4.7...0.4.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.10" # remember to update html_root_url
+version = "0.4.11" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.10"
+    html_root_url = "https://docs.rs/log/0.4.11"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
[Changes since the last release](https://github.com/rust-lang/log/compare/0.4.10...master)

Includes:

- https://github.com/rust-lang/log/pull/373
- https://github.com/rust-lang/log/pull/374
- https://github.com/rust-lang/log/pull/377
- https://github.com/rust-lang/log/pull/379
- https://github.com/rust-lang/log/pull/380
- https://github.com/rust-lang/log/pull/384
- https://github.com/rust-lang/log/pull/392
- https://github.com/rust-lang/log/pull/393
- https://github.com/rust-lang/log/pull/398
- https://github.com/rust-lang/log/pull/400

Most of the new code is in the unstable `kv` module.