### PR TITLE
Allow Level and LevelFilter to deserialize from the index_variant

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -60,6 +60,17 @@ impl<'de> Deserialize<'de> for Level {
 
                 self.visit_str(variant)
             }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let variant: &str = LOG_LEVEL_NAMES[1..]
+                    .get(v as usize)
+                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
+
+                self.visit_str(variant)
+            }
         }
 
         impl<'de> DeserializeSeed<'de> for LevelIdentifier {
@@ -141,6 +152,17 @@ impl<'de> Deserialize<'de> for LevelFilter {
             {
                 let variant = str::from_utf8(value)
                     .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
+
+                self.visit_str(variant)
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let variant: &str = LOG_LEVEL_NAMES
+                    .get(v as usize)
+                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
 
                 self.visit_str(variant)
             }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -61,13 +61,13 @@ impl<'de> Deserialize<'de> for Level {
                 self.visit_str(variant)
             }
 
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
                 let variant = LOG_LEVEL_NAMES[1..]
                     .get(v as usize)
-                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v as u64), &self))?;
+                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
 
                 self.visit_str(variant)
             }
@@ -156,13 +156,13 @@ impl<'de> Deserialize<'de> for LevelFilter {
                 self.visit_str(variant)
             }
 
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: Error,
             {
                 let variant = LOG_LEVEL_NAMES
                     .get(v as usize)
-                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v as u64), &self))?;
+                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
 
                 self.visit_str(variant)
             }


### PR DESCRIPTION
This PR allows the Level and LevelFilter enums to deserialize from the index_variant.

This solves https://github.com/jamesmunns/postcard/issues/24.

Postcard is made to serialize into a compact byte representation, so it takes the index_variant that is provided by the [Serialize implementation](https://github.com/rust-lang/log/blob/master/src/serde.rs#L23). There was however no way to change that back into the enum.