### PR TITLE
Use `std::panic::Location` for file & line information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ std = []
 kv_unstable = []
 kv_unstable_sval = ["kv_unstable", "sval/fmt"]
 
+# requires 1.46.0
+track_caller = []
+
 [dependencies]
 cfg-if = "0.1.2"
 serde = { version = "1.0", optional = true, default-features = false }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -249,9 +249,12 @@ macro_rules! __log_module_path {
 #[macro_export]
 macro_rules! __log_file {
     () => {
-        if cfg!(feature = "track_caller") {
+        #[cfg(feature = "track_caller")]
+        {
             ::std::panic::Location::caller().file()
-        } else {
+        }
+        #[cfg(not(feature = "track_caller"))]
+        {
             file!()
         }
     };
@@ -261,9 +264,12 @@ macro_rules! __log_file {
 #[macro_export]
 macro_rules! __log_line {
     () => {
-        if cfg!(feature = "track_caller") {
+        #[cfg(feature = "track_caller")]
+        {
             ::std::panic::Location::caller().line()
-        } else {
+        }
+        #[cfg(not(feature = "track_caller"))]
+        {
             line!()
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -249,7 +249,11 @@ macro_rules! __log_module_path {
 #[macro_export]
 macro_rules! __log_file {
     () => {
-        file!()
+        if cfg!(feature = "track_caller") {
+            ::std::panic::Location::caller().file()
+        } else {
+            file!()
+        }
     };
 }
 
@@ -257,6 +261,10 @@ macro_rules! __log_file {
 #[macro_export]
 macro_rules! __log_line {
     () => {
-        line!()
+        if cfg!(feature = "track_caller") {
+            ::std::panic::Location::caller().line()
+        } else {
+            line!()
+        }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -247,30 +247,36 @@ macro_rules! __log_module_path {
 
 #[doc(hidden)]
 #[macro_export]
+#[cfg(feature = "track_caller")]
 macro_rules! __log_file {
     () => {
-        #[cfg(feature = "track_caller")]
-        {
-            ::std::panic::Location::caller().file()
-        }
-        #[cfg(not(feature = "track_caller"))]
-        {
-            file!()
-        }
+        ::std::panic::Location::caller().file()
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
+#[cfg(not(feature = "track_caller"))]
+macro_rules! __log_file {
+    () => {
+        file!()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "track_caller")]
 macro_rules! __log_line {
     () => {
-        #[cfg(feature = "track_caller")]
-        {
-            ::std::panic::Location::caller().line()
-        }
-        #[cfg(not(feature = "track_caller"))]
-        {
-            line!()
-        }
+        ::std::panic::Location::caller().line()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "track_caller"))]
+macro_rules! __log_line {
+    () => {
+        line!()
     };
 }


### PR DESCRIPTION
this commit adds a feature, `track_caller`, that allows the user to opt-in to using location information from `std::panic::Location` instead of the built-in `file!` and `line!` macros. This will allow log record location information to be manipulated in the same way that `#[track_caller]` allows panic location information to be manipulated