### PR TITLE
atomics: Add support for targets without atomics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,5 +79,6 @@ jobs:
         run: |
           rustup update stable --no-self-update
           rustup default stable
-      - run: rustup target add thumbv6m-none-eabi
+      - run: rustup target add thumbv6m-none-eabi riscv32imc-unknown-none-elf
       - run: cargo build --verbose --target=thumbv6m-none-eabi
+      - run: cargo build --verbose --target=riscv32imc-unknown-none-elf

--- a/build.rs
+++ b/build.rs
@@ -20,10 +20,16 @@ fn main() {
         None => return,
     };
 
-    // If the target isn't thumbv6 then we can use atomic CAS
-    if !target.starts_with("thumbv6") {
-        println!("cargo:rustc-cfg=atomic_cas");
-    }
+    match &target[..] {
+        "thumbv6m-none-eabi"
+        | "msp430-none-elf"
+        | "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf" => {}
+
+        _ => {
+            println!("cargo:rustc-cfg=atomic_cas");
+        }
+    };
 
     // If the Rust version is at least 1.46.0 then we can use type ids at compile time
     if minor >= 47 {

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,14 @@ fn main() {
         }
     };
 
+    match &target[..] {
+        "msp430-none-elf" | "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => {}
+
+        _ => {
+            println!("cargo:rustc-cfg=has_atomics");
+        }
+    };
+
     // If the Rust version is at least 1.46.0 then we can use type ids at compile time
     if minor >= 47 {
         println!("cargo:rustc-cfg=const_type_id");

--- a/build.rs
+++ b/build.rs
@@ -20,24 +20,13 @@ fn main() {
         None => return,
     };
 
-    match &target[..] {
-        "thumbv6m-none-eabi"
-        | "msp430-none-elf"
-        | "riscv32i-unknown-none-elf"
-        | "riscv32imc-unknown-none-elf" => {}
+    if target_has_atomic_cas(&target) {
+        println!("cargo:rustc-cfg=atomic_cas");
+    }
 
-        _ => {
-            println!("cargo:rustc-cfg=atomic_cas");
-        }
-    };
-
-    match &target[..] {
-        "msp430-none-elf" | "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => {}
-
-        _ => {
-            println!("cargo:rustc-cfg=has_atomics");
-        }
-    };
+    if target_has_atomics(&target) {
+        println!("cargo:rustc-cfg=has_atomics");
+    }
 
     // If the Rust version is at least 1.46.0 then we can use type ids at compile time
     if minor >= 47 {
@@ -50,6 +39,23 @@ fn main() {
 
     println!("cargo:rustc-cfg=srcbuild");
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn target_has_atomic_cas(target: &str) -> bool {
+    match &target[..] {
+        "thumbv6m-none-eabi"
+        | "msp430-none-elf"
+        | "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf" => false,
+        _ => true,
+    }
+}
+
+fn target_has_atomics(target: &str) -> bool {
+    match &target[..] {
+        "msp430-none-elf" | "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => false,
+        _ => true,
+    }
 }
 
 fn rustc_target() -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,6 @@ use std::error;
 use std::fmt;
 use std::mem;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[macro_use]
 mod macros;
@@ -296,6 +295,46 @@ mod serde;
 
 #[cfg(feature = "kv_unstable")]
 pub mod kv;
+
+#[cfg(has_atomics)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(not(has_atomics))]
+use std::cell::Cell;
+#[cfg(not(has_atomics))]
+use std::sync::atomic::Ordering;
+
+#[cfg(not(has_atomics))]
+struct AtomicUsize {
+    v: Cell<usize>,
+}
+
+#[cfg(not(has_atomics))]
+impl AtomicUsize {
+    const fn new(v: usize) -> AtomicUsize {
+        AtomicUsize { v: Cell::new(v) }
+    }
+
+    fn load(&self, _order: Ordering) -> usize {
+        self.v.get()
+    }
+
+    fn store(&self, val: usize, _order: Ordering) {
+        self.v.set(val)
+    }
+
+    #[cfg(atomic_cas)]
+    fn compare_and_swap(&self, current: usize, new: usize, _order: Ordering) -> usize {
+        let prev = self.v.get();
+        if current == prev {
+            self.v.set(new);
+        }
+        prev
+    }
+}
+
+#[cfg(not(has_atomics))]
+unsafe impl Sync for AtomicUsize {}
 
 // The LOGGER static holds a pointer to the global logger. It is protected by
 // the STATE static which determines whether LOGGER has been initialized yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,8 @@ impl AtomicUsize {
     }
 }
 
+// Any platform without atomics is unlikely to have multiple cores, so
+// writing via Cell will not be a race condition.
 #[cfg(not(has_atomics))]
 unsafe impl Sync for AtomicUsize {}
 


### PR DESCRIPTION
Some targets (such as RV32IMC) don't have atomic support. This PR allows the log crate to build for those targets.

As the platform doesn't have atomics we can't implement an Atomic version of AtomicUsize, so this version is not atomic. Any platform without atomics is unlikely to have multiple cores, so this shouldn't be a problem.
    
This is somewhat based on implementations in: https://github.com/japaric/heapless