### PR TITLE
Implement Log for Box<Log>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,6 +1167,23 @@ impl Log for NopLogger {
     fn flush(&self) {}
 }
 
+#[cfg(feature = "std")]
+impl<T> Log for std::boxed::Box<T>
+where
+    T: ?Sized + Log,
+{
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.as_ref().enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        self.as_ref().log(record)
+    }
+    fn flush(&self) {
+        self.as_ref().flush()
+    }
+}
+
 /// Sets the global maximum log level.
 ///
 /// Generally, this should only be called by the active logging implementation.


### PR DESCRIPTION
Hi there! I was trying to wrap a `Box<dyn Log>` returned from [flexi logger](https://docs.rs/flexi_logger/0.16.1/flexi_logger/struct.Logger.html#method.build) into [async_log](https://docs.rs/async-log/2.0.0/async_log/struct.Logger.html#method.wrap) but I was unable to do so since the `Log` trait was not implemented for `Box<dyn Log>`.

One option was to create a wrapper struct:
```
struct LoggerWrapper(Box<dyn Log>);

impl Log for LoggerWrapper {
    fn enabled(&self, metadata: &Metadata) -> bool {
        self.0.enabled(metadata)
    }

    fn log(&self, record: &Record) {
        self.0.log(record)
    }

    fn flush(&self) {
        self.0.flush();
    }
}
```

It was suggested to me that it might be beneficial to have the implementation in the log crate so I've added the implementation in this pull request. 

Would you accept this change? I will be happy to make any changes or modifications if necessary.