### PR TITLE
remove dependency on reverted const type id

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,11 +10,6 @@ use std::str::{self, FromStr};
 mod primitive;
 
 fn main() {
-    let minor = match rustc_minor_version() {
-        Some(minor) => minor,
-        None => return,
-    };
-
     let target = match rustc_target() {
         Some(target) => target,
         None => return,
@@ -26,11 +21,6 @@ fn main() {
 
     if target_has_atomics(&target) {
         println!("cargo:rustc-cfg=has_atomics");
-    }
-
-    // If the Rust version is at least 1.46.0 then we can use type ids at compile time
-    if minor >= 47 {
-        println!("cargo:rustc-cfg=const_type_id");
     }
 
     // Generate sorted type id lookup
@@ -60,34 +50,4 @@ fn target_has_atomics(target: &str) -> bool {
 
 fn rustc_target() -> Option<String> {
     env::var("TARGET").ok()
-}
-
-// From the `serde` build script
-fn rustc_minor_version() -> Option<u32> {
-    let rustc = match env::var_os("RUSTC") {
-        Some(rustc) => rustc,
-        None => return None,
-    };
-
-    let output = match Command::new(rustc).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => return None,
-    };
-
-    let version = match str::from_utf8(&output.stdout) {
-        Ok(version) => version,
-        Err(_) => return None,
-    };
-
-    let mut pieces = version.split('.');
-    if pieces.next() != Some("rustc 1") {
-        return None;
-    }
-
-    let next = match pieces.next() {
-        Some(next) => next,
-        None => return None,
-    };
-
-    u32::from_str(next).ok()
 }


### PR DESCRIPTION
We were going to depend on `const_type_id`, but that feature was reverted before it was stabilized.

I'm working on a refactoring that changes this, but in the meantime anybody depending on `kv_unstable` and building on `1.47.0` is broken. This just removes the expectation that `1.47.0` will allow `const_type_id`.