### PR TITLE
Clarify ordering of log levels in the docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1228,6 +1228,8 @@ where
 /// Sets the global maximum log level.
 ///
 /// Generally, this should only be called by the active logging implementation.
+///
+/// Note that `Trace` is the maximum level, because it provides the maximum amount of detail in the emitted logs.
 #[inline]
 pub fn set_max_level(level: LevelFilter) {
     MAX_LOG_LEVEL_FILTER.store(level as usize, Ordering::SeqCst)


### PR DESCRIPTION
It was not clear whether `error` or `trace` was the maximum log level.
The docs said "`error!` represents the _highest_-priority log messages and `trace!` the _lowest_".
Yet, `set_max_level` regards `Trace` to be the maximum level.

I attempted to clarify this by avoiding the terms "high" and "low" in the docs except for where
they are applicable to the Rust order as defined in `Ord`.

I spent about 30 minutes being confused by this. It seemed to me that `set_max_level` would be used to filter errors and warnings while emitting debug messages, which confused me.

I was going to create an issue first, but decided I would update the docs myself as an initial proposal of how to improve them, so I have created this PR instead.