### PR TITLE
Remove some trailing semicolons from macro definitions

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -71,10 +71,10 @@ macro_rules! log {
 #[macro_export(local_inner_macros)]
 macro_rules! error {
     (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::Level::Error, $($arg)+);
+        log!(target: $target, $crate::Level::Error, $($arg)+)
     );
     ($($arg:tt)+) => (
-        log!($crate::Level::Error, $($arg)+);
+        log!($crate::Level::Error, $($arg)+)
     )
 }
 
@@ -95,10 +95,10 @@ macro_rules! error {
 #[macro_export(local_inner_macros)]
 macro_rules! warn {
     (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::Level::Warn, $($arg)+);
+        log!(target: $target, $crate::Level::Warn, $($arg)+)
     );
     ($($arg:tt)+) => (
-        log!($crate::Level::Warn, $($arg)+);
+        log!($crate::Level::Warn, $($arg)+)
     )
 }
 
@@ -121,10 +121,10 @@ macro_rules! warn {
 #[macro_export(local_inner_macros)]
 macro_rules! info {
     (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::Level::Info, $($arg)+);
+        log!(target: $target, $crate::Level::Info, $($arg)+)
     );
     ($($arg:tt)+) => (
-        log!($crate::Level::Info, $($arg)+);
+        log!($crate::Level::Info, $($arg)+)
     )
 }
 
@@ -146,10 +146,10 @@ macro_rules! info {
 #[macro_export(local_inner_macros)]
 macro_rules! debug {
     (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::Level::Debug, $($arg)+);
+        log!(target: $target, $crate::Level::Debug, $($arg)+)
     );
     ($($arg:tt)+) => (
-        log!($crate::Level::Debug, $($arg)+);
+        log!($crate::Level::Debug, $($arg)+)
     )
 }
 
@@ -173,10 +173,10 @@ macro_rules! debug {
 #[macro_export(local_inner_macros)]
 macro_rules! trace {
     (target: $target:expr, $($arg:tt)+) => (
-        log!(target: $target, $crate::Level::Trace, $($arg)+);
+        log!(target: $target, $crate::Level::Trace, $($arg)+)
     );
     ($($arg:tt)+) => (
-        log!($crate::Level::Trace, $($arg)+);
+        log!($crate::Level::Trace, $($arg)+)
     )
 }
 


### PR DESCRIPTION
This will allow these macros to continue to be used in expression
position if https://github.com/rust-lang/rust/issues/33953 is fixed.