### PR TITLE
Key-value serializer adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,7 @@ sval = { version = "1.0.0-alpha.4", optional = true, default-features = false }
 value-bag = { version = "1.0.0-alpha.5", optional = true, default-features = false }
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 serde_test = "1.0"
+sval = { version = "1.0.0-alpha.4", features = ["derive"] }
 value-bag = { version = "1.0.0-alpha.5", features = ["test"] }

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -128,6 +128,39 @@ mod std_support {
     }
 }
 
+#[cfg(feature = "kv_unstable_sval")]
+mod sval_support {
+    use super::*;
+
+    extern crate sval;
+
+    use self::sval::value::{self, Value};
+
+    impl<'a> Value for Key<'a> {
+        fn stream(&self, stream: &mut value::Stream) -> value::Result {
+            self.key.stream(stream)
+        }
+    }
+}
+
+#[cfg(feature = "kv_unstable_serde")]
+mod serde_support {
+    use super::*;
+
+    extern crate serde;
+
+    use self::serde::{Serialize, Serializer};
+
+    impl<'a> Serialize for Key<'a> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.key.serialize(serializer)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -14,7 +14,7 @@
 
 mod error;
 mod key;
-mod source;
+pub mod source;
 
 pub mod value;
 

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -253,6 +253,16 @@ impl<'v> Value<'v> {
             inner: value.into(),
         }
     }
+
+    /// Check whether this value can be downcast to `T`.
+    pub fn is<T: 'static>(&self) -> bool {
+        self.inner.is::<T>()
+    }
+
+    /// Try downcast this value to `T`.
+    pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.inner.downcast_ref::<T>()
+    }
 }
 
 impl<'v> fmt::Debug for Value<'v> {
@@ -655,5 +665,16 @@ pub(crate) mod tests {
         {
             assert!(v.to_char().is_none());
         }
+    }
+
+    #[test]
+    fn test_downcast_ref() {
+        #[derive(Debug)]
+        struct Foo(u64);
+
+        let v = Value::capture_debug(&Foo(42));
+
+        assert!(v.is::<Foo>());
+        assert_eq!(42u64, v.downcast_ref::<Foo>().expect("invalid downcast").0);
     }
 }


### PR DESCRIPTION
This PR does two things:

- Exposes the `Value::downcast_ref` method that was missed in #423 
- Adds adapters so that `Source`s can be treated like a map or sequence for formatting or serialization

This means `Log` implementors can now write something like:

```rust
use log::kv::source;

#[derive(Serialize)]
pub struct MyRecordAsMap<'a> {
    msg: &'a str,
    #[serde(flatten)]
    #[serde(with = "source::as_map")]
    kvs: &'a dyn Source,
}
```

to define a type that can be serialized using `serde` as a map with key values flattened.