### PR TITLE
Add a prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ mod serde;
 pub mod kv;
 
 pub mod prelude {
-    pub use macros::{log, debug, error, info, trace, warn};
+    pub use crate::{log, debug, error, info, trace, warn};
 }
 
 #[cfg(has_atomics)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,10 @@ mod serde;
 #[cfg(feature = "kv_unstable")]
 pub mod kv;
 
+pub mod prelude {
+    pub use macros::{log, debug, error, info, trace, warn};
+}
+
 #[cfg(has_atomics)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 


### PR DESCRIPTION
This PR adds a `prelude` module that makes it easier to import the logging macros. You can now glob import `prelude` as opposed to naming the macros explicitly:
```rust
use log::prelude::*;

// instead of
use log::{warn, trace, debug, log, info, error}
```

The current workarounds are to use the old `extern crate` syntax:
```rust
#[macro_use]
extern crate log;
```

Or to use them without an import:
```rust
log::warn!("...");
```

However, many people prefer not having to write the longer name, and a `prelude` module makes this easier:
```rust
use log::prelude::*;

warn!("...");
```