### PR TITLE
check std feature against kv_unstable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
     - run: cargo test --verbose --features kv_unstable
     - run: cargo test --verbose --features "kv_unstable std"
     - run: cargo test --verbose --features "kv_unstable_sval"
+    - run: cargo test --verbose --features "kv_unstable_sval std"
+    - run: cargo test --verbose --features "kv_unstable kv_unstable_std kv_unstable_sval kv_unstable_serde"
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,8 @@ jobs:
     - run: cargo test --verbose --features serde
     - run: cargo test --verbose --features std
     - run: cargo test --verbose --features kv_unstable
-    - run: cargo test --verbose --features "kv_unstable std"
-    - run: cargo test --verbose --features "kv_unstable_sval"
-    - run: cargo test --verbose --features "kv_unstable_sval std"
+    - run: cargo test --verbose --features kv_unstable_sval
+    - run: cargo test --verbose --features kv_unstable_serde
     - run: cargo test --verbose --features "kv_unstable kv_unstable_std kv_unstable_sval kv_unstable_serde"
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
@@ -58,6 +57,22 @@ jobs:
         rustup default stable
         rustup component add rustfmt
     - run: cargo fmt -- --check
+
+  features:
+    name: Feature check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: |
+          rustup update nightly --no-self-update
+          rustup default nightly
+      - run: cargo build --verbose -Z avoid-dev-deps --features kv_unstable
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable std"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_sval"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_serde"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_std"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_sval kv_unstable_serde"
 
   msrv:
     name: MSRV

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -427,7 +427,7 @@ impl<'v> Value<'v> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "kv_unstable_std")]
 mod std_support {
     use super::*;
 
@@ -615,7 +615,7 @@ pub(crate) mod tests {
         for v in str() {
             assert!(v.to_borrowed_str().is_some());
 
-            #[cfg(feature = "std")]
+            #[cfg(feature = "kv_unstable_std")]
             assert!(v.to_str().is_some());
         }
 
@@ -624,13 +624,13 @@ pub(crate) mod tests {
 
         assert!(v.to_borrowed_str().is_some());
 
-        #[cfg(feature = "std")]
+        #[cfg(feature = "kv_unstable_std")]
         assert!(v.to_str().is_some());
 
         for v in unsigned().chain(signed()).chain(float()).chain(bool()) {
             assert!(v.to_borrowed_str().is_none());
 
-            #[cfg(feature = "std")]
+            #[cfg(feature = "kv_unstable_std")]
             assert!(v.to_str().is_none());
         }
     }


### PR DESCRIPTION
Closes #433 

There's an incorrect `#[cfg(feature = "std")]` in `kv::value` that's broken users upgrading to `0.4.12`. This PR fixes that up and runs a few more permutations in CI.