### PR TITLE
Prepare for 0.4.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.4.13] - 2020-01-08
+
+### Fixed
+
+* Fixed incorrect combination of `kv_unstable` and `std` features causing compile failures
+
 ## [0.4.12] - 2020-12-24
 
 ### New
@@ -185,7 +191,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.12...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.13...HEAD
+[0.4.13]: https://github.com/rust-lang-nursery/log/compare/0.4.12...0.4.13
 [0.4.12]: https://github.com/rust-lang-nursery/log/compare/0.4.11...0.4.12
 [0.4.11]: https://github.com/rust-lang-nursery/log/compare/0.4.10...0.4.11
 [0.4.10]: https://github.com/rust-lang-nursery/log/compare/0.4.9...0.4.10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.12" # remember to update html_root_url
+version = "0.4.13" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.12"
+    html_root_url = "https://docs.rs/log/0.4.13"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
cc @fggarcia @Byron

This includes #434, which was a bug when a combination of `kv_unstable` and `std` features was enabled in `log`.