### PR TITLE
Prepare for 0.4.13 release patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.13] - 2021-01-11
+
+* This is the same as `0.4.11`, except with a `kv_unstable_std` feature added to aid migrating current dependents to `0.4.14` (which was originally going to be `0.4.13` until it was decided to create a patch from `0.4.11` to minimize disruption).
+
 ## [0.4.11] - 2020-07-09
 
 ### New
@@ -170,7 +174,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.11...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.13...HEAD
+[0.4.13]: https://github.com/rust-lang-nursery/log/compare/0.4.11...0.4.13
 [0.4.11]: https://github.com/rust-lang-nursery/log/compare/0.4.10...0.4.11
 [0.4.10]: https://github.com/rust-lang-nursery/log/compare/0.4.9...0.4.10
 [0.4.9]: https://github.com/rust-lang-nursery/log/compare/0.4.8...0.4.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.11" # remember to update html_root_url
+version = "0.4.13" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -46,6 +46,7 @@ std = []
 # requires the latest stable
 # this will have a tighter MSRV before stabilization
 kv_unstable = []
+kv_unstable_std = ["kv_unstable", "std"]
 kv_unstable_sval = ["kv_unstable", "sval/fmt"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.11"
+    html_root_url = "https://docs.rs/log/0.4.13"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
For #437 

This creates a patch release from `0.4.11` with an additional `kv_unstable_std` feature. I'm going to PR repositories that are currently depending on `kv_unstable` and `std` and this patch release will minimize any disruption caused by the change in features in the meantime.

What's currently `0.4.13` will now become `0.4.14`.