### PR TITLE
Remove the `__private_api_log_lit` special case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1471,25 +1471,6 @@ pub fn __private_api_log(
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
 #[doc(hidden)]
-pub fn __private_api_log_lit(
-    message: &str,
-    level: Level,
-    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-) {
-    logger().log(
-        &Record::builder()
-            .args(format_args!("{}", message))
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .build(),
-    );
-}
-
-// WARNING: this is not part of the crate's public API and is subject to change at any time
-#[doc(hidden)]
 pub fn __private_api_enabled(level: Level, target: &str) -> bool {
     logger().enabled(&Metadata::builder().level(level).target(target).build())
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,18 +29,6 @@
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! log {
-    (target: $target:expr, $lvl:expr, $message:expr) => ({
-        let lvl = $lvl;
-        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
-            // ensure that $message is a valid format string literal
-            let _ = __log_format_args!($message);
-            $crate::__private_api_log_lit(
-                $message,
-                lvl,
-                &($target, __log_module_path!(), __log_file!(), __log_line!()),
-            );
-        }
-    });
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {


### PR DESCRIPTION
https://github.com/rust-lang/log/issues/445#issuecomment-765965279:
> That special case existed to minimize the amount of code generated, but it's not compatible with format_args_capture as you pointed out. It should just be removed.

Closes #445.

I did not add a test for `format_args_capture`. I think I need to create a custom logger to capture records and add a testing-only crate feature or `--cfg` (to tell if `#![feature(format_args_capture)]` is allowed to use) to test it. `format_args_capture` is *unstable* now, I'm not sure if it worths it. Feel free to ask me to add such test if it's necessary.