### PR TITLE
Allow use of deprecated atomic::spin_loop_hint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1362,6 +1362,8 @@ where
         }
         INITIALIZING => {
             while STATE.load(Ordering::SeqCst) == INITIALIZING {
+                // TODO: replace with `hint::spin_loop` once MSRV is 1.49.0.
+                #[allow(deprecated)]
                 std::sync::atomic::spin_loop_hint();
             }
             Err(SetLoggerError(()))


### PR DESCRIPTION
It's replaced by `hint::spin_loop`, however that has only been stable
since 1.49.0. Since we still support 1.31.0 we can't use it. Once the
MSRV is updated to 1.49 we can use `hint::spin_loop`.