### PR TITLE
Add `unset_logger`, `unset_boxed_logger` and `reset_max_level` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ name = "macros"
 path = "tests/macros.rs"
 harness = true
 
+[[test]]
+name = "unset"
+path = "tests/unset.rs"
+harness = true
+
 [features]
 max_level_off   = []
 max_level_error = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1459,7 +1459,8 @@ pub unsafe fn unset_boxed_logger() {
 }
 
 #[cfg(atomic_cas)]
-fn unset_logger_inner(#[cfg(feature = "std")] boxed: bool, #[cfg(not(feature = "std"))] _: bool) {
+#[allow(unused_variables)]
+fn unset_logger_inner(boxed: bool) {
     let old_state = match STATE.compare_exchange(
         INITIALIZED,
         UNINITIALIZING,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,9 @@ const INITIALIZING: usize = 1;
 const INITIALIZED: usize = 2;
 const UNINITIALIZING: usize = 3;
 
-static MAX_LOG_LEVEL_FILTER: AtomicUsize = AtomicUsize::new(0);
+const DEFAULT_LOG_LEVEL_FILTER: usize = 0;
+
+static MAX_LOG_LEVEL_FILTER: AtomicUsize = AtomicUsize::new(DEFAULT_LOG_LEVEL_FILTER);
 
 static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
@@ -1238,6 +1240,14 @@ where
 #[inline]
 pub fn set_max_level(level: LevelFilter) {
     MAX_LOG_LEVEL_FILTER.store(level as usize, Ordering::SeqCst)
+}
+
+/// Resets the global maximum log level.
+///
+/// Typically, this will only be used in tests to reset global state.
+#[inline]
+pub fn reset_max_level() {
+    MAX_LOG_LEVEL_FILTER.store(DEFAULT_LOG_LEVEL_FILTER, Ordering::SeqCst)
 }
 
 /// Returns the current maximum log level.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1472,8 +1472,10 @@ fn unset_logger_inner(boxed: bool) {
     match old_state {
         INITIALIZED => {
             #[cfg(feature = "std")]
-            if boxed {
-                unsafe { Box::from_raw(LOGGER as *const _ as *mut dyn Log) };
+            {
+                if boxed {
+                    unsafe { Box::from_raw(LOGGER as *const _ as *mut dyn Log) };
+                }
             }
             unsafe {
                 LOGGER = &NopLogger;

--- a/test_max_level_features/main.rs
+++ b/test_max_level_features/main.rs
@@ -40,6 +40,10 @@ fn main() {
     test(&a, LevelFilter::Info);
     test(&a, LevelFilter::Debug);
     test(&a, LevelFilter::Trace);
+
+    log::reset_max_level();
+    error!("");
+    last(&a, None);
 }
 
 fn test(a: &State, filter: LevelFilter) {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -44,6 +44,10 @@ fn main() {
     test(&a, LevelFilter::Info);
     test(&a, LevelFilter::Debug);
     test(&a, LevelFilter::Trace);
+
+    log::reset_max_level();
+    error!("");
+    last(&a, None);
 }
 
 fn test(a: &State, filter: LevelFilter) {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -16,3 +16,7 @@ mod filters;
 #[cfg(test)]
 #[path = "../macros.rs"]
 mod macros;
+
+#[cfg(test)]
+#[path = "../unset.rs"]
+mod unset;

--- a/tests/unset.rs
+++ b/tests/unset.rs
@@ -1,0 +1,54 @@
+#[cfg(not(lib_build))]
+#[macro_use]
+extern crate log;
+
+#[cfg(feature = "std")]
+use log::set_boxed_logger;
+
+#[cfg(not(feature = "std"))]
+fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
+    log::set_logger(Box::leak(logger))
+}
+
+use log::{LevelFilter, Log, Metadata, Record};
+use std::sync::{Arc, Mutex};
+
+struct State {
+    log_count: Mutex<usize>,
+}
+
+struct Logger(Arc<State>);
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, _: &Record) {
+        *self.0.log_count.lock().unwrap() += 1;
+    }
+
+    fn flush(&self) {}
+}
+
+#[test]
+fn unset() {
+    let state = Arc::new(State {
+        log_count: Mutex::new(0),
+    });
+
+    let logger = Box::new(Logger(state.clone()));
+
+    set_boxed_logger(logger).unwrap();
+    log::set_max_level(LevelFilter::Error);
+
+    error!("");
+
+    assert_eq!(*state.clone().log_count.lock().unwrap(), 1);
+
+    log::unset_logger();
+
+    error!("");
+
+    assert_eq!(*state.clone().log_count.lock().unwrap(), 1);
+}

--- a/tests/unset.rs
+++ b/tests/unset.rs
@@ -52,15 +52,15 @@ fn unset() {
 
     error!("");
 
-    assert_eq!(*state1.clone().log_count.lock().unwrap(), 1);
+    assert_eq!(*state1.log_count.lock().unwrap(), 1);
 
     unsafe { unset_boxed_logger() };
 
-    assert_eq!(*state1.clone().dropped.lock().unwrap(), true);
+    assert_eq!(*state1.dropped.lock().unwrap(), true);
 
     error!("");
 
-    assert_eq!(*state1.clone().log_count.lock().unwrap(), 1);
+    assert_eq!(*state1.log_count.lock().unwrap(), 1);
 
     let state2 = Arc::new(State {
         log_count: Mutex::new(0),
@@ -73,8 +73,8 @@ fn unset() {
 
     error!("");
 
-    assert_eq!(*state2.clone().log_count.lock().unwrap(), 1);
-    assert_eq!(*state1.clone().log_count.lock().unwrap(), 1);
+    assert_eq!(*state2.log_count.lock().unwrap(), 1);
+    assert_eq!(*state1.log_count.lock().unwrap(), 1);
 }
 
 #[test]
@@ -94,11 +94,11 @@ fn unset() {
 
     error!("");
 
-    assert_eq!(*state.clone().log_count.lock().unwrap(), 1);
+    assert_eq!(*state.log_count.lock().unwrap(), 1);
 
     unset_logger();
 
     error!("");
 
-    assert_eq!(*state.clone().log_count.lock().unwrap(), 1);
+    assert_eq!(*state.log_count.lock().unwrap(), 1);
 }


### PR DESCRIPTION
Hey there!

Specifically for testing, it would be handy if the globals could be restored to their initial state.

This PR adds an `unset_logger`, `unset_boxed_logger` and `reset_max_level` function to accomplish that.

---

Btw. I was wondering what the purpose of the `test_max_level_features` folder is, since the `tests/filters.rs` file seems to accomplish the same.