### PR TITLE
Expose logging levels 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,6 +562,8 @@ impl Level {
     }
 
     /// Iterate through all supported logging levels
+    ///
+    /// The order of iteration is from more severe to less severe log messages
     pub fn iter() -> impl Iterator<Item = Self> {
         (1..).flat_map(Self::from_usize)
     }
@@ -729,6 +731,8 @@ impl LevelFilter {
     }
 
     /// Iterate through all supported filtering levels
+    ///
+    /// The order of iteration is from less to more verbose filtering
     pub fn iter() -> impl Iterator<Item = Self> {
         (0..).flat_map(Self::from_usize)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,7 @@ impl Level {
 
     /// Iterate through all supported logging levels
     pub fn iter() -> impl Iterator<Item = Self> {
-        (0..).flat_map(Self::from_usize)
+        (1..).flat_map(Self::from_usize)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,12 @@ const INITIALIZED: usize = 2;
 
 static MAX_LOG_LEVEL_FILTER: AtomicUsize = AtomicUsize::new(0);
 
-static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+/// Array of supported filter levels for a logger.
+///
+/// Values correspond to the variants of the [`LevelFilter`](enum.LevelFilter.html) enum.
+///
+/// Can be used, for example, in help text shown to a user of an application.
+pub static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
 static SET_LOGGER_ERROR: &str = "attempted to set a logger after the logging system \
                                  was already initialized";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,12 +359,7 @@ const INITIALIZED: usize = 2;
 
 static MAX_LOG_LEVEL_FILTER: AtomicUsize = AtomicUsize::new(0);
 
-/// Array of supported filter levels for a logger.
-///
-/// Values correspond to the variants of the [`LevelFilter`](enum.LevelFilter.html) enum.
-///
-/// Can be used, for example, in help text shown to a user of an application.
-pub static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+static LOG_LEVEL_NAMES: [&str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
 static SET_LOGGER_ERROR: &str = "attempted to set a logger after the logging system \
                                  was already initialized";
@@ -565,6 +560,11 @@ impl Level {
     pub fn as_str(&self) -> &'static str {
         LOG_LEVEL_NAMES[*self as usize]
     }
+
+    /// Iterate through all supported logging levels
+    pub fn iter() -> impl Iterator<Item = Self> {
+        (0..).flat_map(Self::from_usize)
+    }
 }
 
 /// An enum representing the available verbosity level filters of the logger.
@@ -726,6 +726,11 @@ impl LevelFilter {
     /// This returns the same string as the `fmt::Display` implementation.
     pub fn as_str(&self) -> &'static str {
         LOG_LEVEL_NAMES[*self as usize]
+    }
+
+    /// Iterate through all supported filtering levels
+    pub fn iter() -> impl Iterator<Item = Self> {
+        (0..).flat_map(Self::from_usize)
     }
 }
 


### PR DESCRIPTION
I am using `FromStr` implementation of `LevelFilter` to parse logging level given by user via command line flag. In case user gives invalid logging level I want to print list of allowed values. Currently I have to replicate `LOG_LEVEL_NAMES` array in my code and remember to keep it in sync (It is probably unlikely it changes that much though).

One question I have is that is there a reason it is `static` instead of `const`?