### PR TITLE
Pin alpha deps so they're not automatically bumped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]
 [dependencies]
 cfg-if = "1.0"
 serde = { version = "1.0", optional = true, default-features = false }
-sval = { version = "1.0.0-alpha.5", optional = true, default-features = false }
-value-bag = { version = "1.0.0-alpha.6", optional = true, default-features = false }
+sval = { version = "=1.0.0-alpha.5", optional = true, default-features = false }
+value-bag = { version = "=1.0.0-alpha.8", optional = true, default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_test = "1.0"
-sval = { version = "1.0.0-alpha.5", features = ["derive"] }
-value-bag = { version = "1.0.0-alpha.6", features = ["test"] }
+sval = { version = "=1.0.0-alpha.5", features = ["derive"] }
+value-bag = { version = "=1.0.0-alpha.8", features = ["test"] }


### PR DESCRIPTION
I misunderstood how `*-alpha` dependencies would be treated, assuming they wouldn't be considered semver compatible. This PR pins these private dependencies of the key-value implementation to protect `log` users from any intermediate breakage in them while they're getting polished up.