### PR TITLE
Fix up level iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,7 +576,7 @@ impl Level {
     /// assert_eq!(Some(Level::Trace), levels.last());
     /// ```
     pub fn iter() -> impl Iterator<Item = Self> {
-        (1..6).flat_map(Self::from_usize)
+        (1..6).map(|i| Self::from_usize(i).unwrap())
     }
 }
 
@@ -757,7 +757,7 @@ impl LevelFilter {
     /// assert_eq!(Some(LevelFilter::Trace), levels.last());
     /// ```
     pub fn iter() -> impl Iterator<Item = Self> {
-        (0..6).flat_map(Self::from_usize)
+        (0..6).map(|i| Self::from_usize(i).unwrap())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,11 +561,22 @@ impl Level {
         LOG_LEVEL_NAMES[*self as usize]
     }
 
-    /// Iterate through all supported logging levels
+    /// Iterate through all supported logging levels.
     ///
-    /// The order of iteration is from more severe to less severe log messages
+    /// The order of iteration is from more severe to less severe log messages.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use log::Level;
+    ///
+    /// let mut levels = Level::iter();
+    ///
+    /// assert_eq!(Some(Level::Error), levels.next());
+    /// assert_eq!(Some(Level::Trace), levels.last());
+    /// ```
     pub fn iter() -> impl Iterator<Item = Self> {
-        (1..).flat_map(Self::from_usize)
+        (1..6).flat_map(Self::from_usize)
     }
 }
 
@@ -709,6 +720,7 @@ impl LevelFilter {
             _ => None,
         }
     }
+
     /// Returns the most verbose logging level filter.
     #[inline]
     pub fn max() -> LevelFilter {
@@ -730,11 +742,22 @@ impl LevelFilter {
         LOG_LEVEL_NAMES[*self as usize]
     }
 
-    /// Iterate through all supported filtering levels
+    /// Iterate through all supported filtering levels.
     ///
-    /// The order of iteration is from less to more verbose filtering
+    /// The order of iteration is from less to more verbose filtering.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use log::LevelFilter;
+    ///
+    /// let mut levels = LevelFilter::iter();
+    ///
+    /// assert_eq!(Some(LevelFilter::Off), levels.next());
+    /// assert_eq!(Some(LevelFilter::Trace), levels.last());
+    /// ```
     pub fn iter() -> impl Iterator<Item = Self> {
-        (0..).flat_map(Self::from_usize)
+        (0..6).flat_map(Self::from_usize)
     }
 }
 
@@ -928,7 +951,6 @@ impl<'a> Record<'a> {
 /// the created object when `build` is called.
 ///
 /// # Examples
-///
 ///
 /// ```edition2018
 /// use log::{Level, Record};


### PR DESCRIPTION
Follow up to #459 

Adds some doc tests for iterating over levels and filters and fixes up an infinite loop in the implementation.