### PR TITLE
Fix tests when running with --all-features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
         rustup update ${{ matrix.rust }} --no-self-update
         rustup default ${{ matrix.rust }}
     - run: cargo test --verbose
+    - run: cargo test --verbose --no-default-features
+    - run: cargo test --verbose --all-features
     - run: cargo test --verbose --features serde
     - run: cargo test --verbose --features std
     - run: cargo test --verbose --features kv_unstable

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports)]
+
 #[cfg(not(lib_build))]
 #[macro_use]
 extern crate log;
@@ -32,18 +34,36 @@ impl Log for Logger {
 
 #[cfg_attr(lib_build, test)]
 fn main() {
-    let me = Arc::new(State {
-        last_log: Mutex::new(None),
-    });
-    let a = me.clone();
-    set_boxed_logger(Box::new(Logger(me))).unwrap();
+    // These tests don't really make sense when static
+    // max level filtering is applied
+    #[cfg(not(any(
+        feature = "max_level_off",
+        feature = "max_level_error",
+        feature = "max_level_warn",
+        feature = "max_level_info",
+        feature = "max_level_debug",
+        feature = "max_level_trace",
+        feature = "max_level_off",
+        feature = "max_level_error",
+        feature = "max_level_warn",
+        feature = "max_level_info",
+        feature = "max_level_debug",
+        feature = "max_level_trace",
+    )))]
+    {
+        let me = Arc::new(State {
+            last_log: Mutex::new(None),
+        });
+        let a = me.clone();
+        set_boxed_logger(Box::new(Logger(me))).unwrap();
 
-    test(&a, LevelFilter::Off);
-    test(&a, LevelFilter::Error);
-    test(&a, LevelFilter::Warn);
-    test(&a, LevelFilter::Info);
-    test(&a, LevelFilter::Debug);
-    test(&a, LevelFilter::Trace);
+        test(&a, LevelFilter::Off);
+        test(&a, LevelFilter::Error);
+        test(&a, LevelFilter::Warn);
+        test(&a, LevelFilter::Info);
+        test(&a, LevelFilter::Debug);
+        test(&a, LevelFilter::Trace);
+    }
 }
 
 fn test(a: &State, filter: LevelFilter) {


### PR DESCRIPTION
Closes #381

The filtering tests don't really make sense in the presence of static max level filters. This PR just no-ops them when any of these is enabled. That way we still run them with the default `cargo test`, but make it possible to also run `cargo test --all-features`.