### PR TITLE
Add Log implementation for &impl Log and Arc<impl Log>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1284,24 +1284,6 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<P, T> Log for std::pin::Pin<P>
-where
-    P: std::ops::Deref<Target = T> + std::marker::Send + std::marker::Sync,
-    T: Log + ?Sized,
-{
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        (**self).enabled(metadata)
-    }
-
-    fn log(&self, record: &Record) {
-        (**self).log(record)
-    }
-    fn flush(&self) {
-        (**self).flush()
-    }
-}
-
-#[cfg(feature = "std")]
 impl<T> Log for std::sync::Arc<T>
 where
     T: ?Sized + Log,
@@ -1900,7 +1882,7 @@ mod tests {
     fn test_foreign_impl() {
         use super::Log;
         #[cfg(feature = "std")]
-        use std::{pin::Pin, sync::Arc};
+        use std::sync::Arc;
 
         fn assert_is_log<T: Log + ?Sized>() {}
 
@@ -1910,9 +1892,6 @@ mod tests {
         assert_is_log::<Box<dyn Log>>();
 
         #[cfg(feature = "std")]
-        assert_is_log::<Pin<Box<dyn Log>>>();
-
-        #[cfg(feature = "std")]
         assert_is_log::<Arc<dyn Log>>();
 
         // Assert these statements for all T: Log + ?Sized
@@ -1920,9 +1899,6 @@ mod tests {
         fn forall<T: Log + ?Sized>() {
             #[cfg(feature = "std")]
             assert_is_log::<Box<T>>();
-
-            #[cfg(feature = "std")]
-            assert_is_log::<Pin<Box<T>>>();
 
             assert_is_log::<&T>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@
     html_root_url = "https://docs.rs/log/0.4.14"
 )]
 #![warn(missing_docs)]
-#![deny(missing_debug_implementations)]
+#![deny(missing_debug_implementations, unconditional_recursion)]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // When compiled for the rustc compiler itself we want to make sure that this is
 // an unstable crate
@@ -1250,8 +1250,59 @@ impl Log for NopLogger {
     fn flush(&self) {}
 }
 
+impl<T> Log for &'_ T
+where
+    T: ?Sized + Log,
+{
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        (**self).enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        (**self).log(record)
+    }
+    fn flush(&self) {
+        (**self).flush()
+    }
+}
+
 #[cfg(feature = "std")]
 impl<T> Log for std::boxed::Box<T>
+where
+    T: ?Sized + Log,
+{
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.as_ref().enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        self.as_ref().log(record)
+    }
+    fn flush(&self) {
+        self.as_ref().flush()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<P, T> Log for std::pin::Pin<P>
+where
+    P: std::ops::Deref<Target = T> + std::marker::Send + std::marker::Sync,
+    T: Log + ?Sized,
+{
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        (**self).enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        (**self).log(record)
+    }
+    fn flush(&self) {
+        (**self).flush()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> Log for std::sync::Arc<T>
 where
     T: ?Sized + Log,
 {
@@ -1841,5 +1892,42 @@ mod tests {
                 .to_borrowed_str()
                 .expect("invalid value")
         );
+    }
+
+    // Test that the `impl Log for Foo` blocks work
+    // This test mostly operates on a type level, so failures will be compile errors
+    #[test]
+    fn test_foreign_impl() {
+        use super::Log;
+        #[cfg(feature = "std")]
+        use std::{pin::Pin, sync::Arc};
+
+        fn assert_is_log<T: Log + ?Sized>() {}
+
+        assert_is_log::<&dyn Log>();
+
+        #[cfg(feature = "std")]
+        assert_is_log::<Box<dyn Log>>();
+
+        #[cfg(feature = "std")]
+        assert_is_log::<Pin<Box<dyn Log>>>();
+
+        #[cfg(feature = "std")]
+        assert_is_log::<Arc<dyn Log>>();
+
+        // Assert these statements for all T: Log + ?Sized
+        #[allow(unused)]
+        fn forall<T: Log + ?Sized>() {
+            #[cfg(feature = "std")]
+            assert_is_log::<Box<T>>();
+
+            #[cfg(feature = "std")]
+            assert_is_log::<Pin<Box<T>>>();
+
+            assert_is_log::<&T>();
+
+            #[cfg(feature = "std")]
+            assert_is_log::<Arc<T>>();
+        }
     }
 }


### PR DESCRIPTION
Closes #458. Turns out that `Rc<Log>` isn't possible because `Log: Sync`. Other candidates for adding:

- `Cow`
- `Option`
- `()` (this would allow us to get rid of the internal `NopLogger`)
- `Pin` (?)
- Probably forgot something