### PR TITLE
Check features with minimal versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,22 @@ jobs:
       - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_std"
       - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_sval kv_unstable_serde"
 
+  features:
+    name: Minimal versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: |
+          rustup update nightly --no-self-update
+          rustup default nightly
+      - run: cargo build --verbose -Z minimal-versions --features kv_unstable
+      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable std"
+      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_sval"
+      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_serde"
+      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_std"
+      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_sval kv_unstable_serde"
+
   msrv:
     name: MSRV
     runs-on: ubuntu-latest


### PR DESCRIPTION
Inspired by #480 

We don't have many dependencies in `log`, and they're all optional, but it seems like a good time to start checking to make sure we use minimal-version-compatible bounds where those dependencies do appear. If this starts to break due to one of our dependencies not complying then we can decide at that point whether to keep it or can it.