### PR TITLE
Prepare for 0.4.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.4.15] - 2022-02-23
+
+* Silence a warning about the deprecated `spin_loop_hint`.
+* Relax ordering in the atomic `set_max_level` call.
+* Allow levels to be iterated over.
+* Implement `Log` on some common wrapper types.
+* Improvements to test coverage.
+* Improvements to documentation.
+* Add key-value support to the `log!` macros.
+* Tighten `kv_unstable` internal dependencies so they don't bump past their current alpha.
+* Add a simple visit API to `kv_unstable`.
+
 ## [0.4.14] - 2021-01-27
 
 * Remove the `__private_api_log_lit` special case.
@@ -196,7 +208,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.14...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.15...HEAD
+[0.4.15]: https://github.com/rust-lang-nursery/log/compare/0.4.13...0.4.15
 [0.4.14]: https://github.com/rust-lang-nursery/log/compare/0.4.13...0.4.14
 [0.4.13]: https://github.com/rust-lang-nursery/log/compare/0.4.11...0.4.13
 [0.4.12]: https://github.com/rust-lang-nursery/log/compare/0.4.11...0.4.12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.14" # remember to update html_root_url
+version = "0.4.15" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.14"
+    html_root_url = "https://docs.rs/log/0.4.15"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
[Changes since the last release](https://github.com/rust-lang/log/compare/0.4.14...HEAD)

This includes:

- #454 
- #449 
- #465 
- #464 
- #463 
- #461 
- #420 
- #467 
- #459 
- #468 
- #469 
- #470 
- #471 
- #473 
- #475 
- #476 
- #479 
- #478 
- #482 
- #483 
