### PR TITLE
#487 Add thumbv4t-none-eabi to the list of targets that don't support…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,10 @@ fn target_has_atomic_cas(target: &str) -> bool {
 
 fn target_has_atomics(target: &str) -> bool {
     match &target[..] {
-        "thumbv4t-none-eabi" | "msp430-none-elf" | "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => false,
+        "thumbv4t-none-eabi"
+        | "msp430-none-elf"
+        | "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf" => false,
         _ => true,
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,7 @@ fn target_has_atomic_cas(target: &str) -> bool {
 
 fn target_has_atomics(target: &str) -> bool {
     match &target[..] {
-        "msp430-none-elf" | "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => false,
+        "thumbv4t-none-eabi" | "msp430-none-elf" | "riscv32i-unknown-none-elf" | "riscv32imc-unknown-none-elf" => false,
         _ => true,
     }
 }


### PR DESCRIPTION
Add `thumbv4t-none-eabi` to the list of targets that don't support atomics.

With this change, it builds fine for `thumbv4t-none-eabi`.

Without this change, I get a build failure for `thumbv4t-none-eabi`:
```
    Blocking waiting for file lock on package cache
    Updating crates.io index
    Blocking waiting for file lock on package cache
   Compiling log v0.4.14
   Compiling cfg-if v1.0.0
error[E0599]: no method named `compare_exchange` found for struct `AtomicUsize` in the current scope
    --> /Users/walter/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/lib.rs:1347:33
     |
1347 |     let old_state = match STATE.compare_exchange(
     |                                 ^^^^^^^^^^^^^^^^ method not found in `AtomicUsize`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `log` due to previous error
```