### PR TITLE
Add reference to db_logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ There are many available implementations to choose from, here are some of the mo
     * [`slog-stdlog`](https://docs.rs/slog-stdlog/*/slog_stdlog/)
     * [`android_log`](https://docs.rs/android_log/*/android_log/)
     * [`win_dbg_logger`](https://docs.rs/win_dbg_logger/*/win_dbg_logger/)
+    * [`db_logger`](https://docs.rs/db_logger/*/db_logger/)
 * For WebAssembly binaries:
     * [`console_log`](https://docs.rs/console_log/*/console_log/)
 * For dynamic libraries:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@
 //!     * [systemd-journal-logger]
 //!     * [android_log]
 //!     * [win_dbg_logger]
+//!     * [db_logger]
 //! * For WebAssembly binaries:
 //!     * [console_log]
 //! * For dynamic libraries:


### PR DESCRIPTION
db_logger is a logging implementation that writes log entries to a
database.  At the time of this writing, it supports PostgreSQL and
SQLite via the sqlx crate.