### PR TITLE
Upgrade to value-bag 1.0.0-alpha.9 and remove by-value 128bit int conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,11 @@ kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]
 cfg-if = "1.0"
 serde = { version = "1.0", optional = true, default-features = false }
 sval = { version = "=1.0.0-alpha.5", optional = true, default-features = false }
-value-bag = { version = "=1.0.0-alpha.8", optional = true, default-features = false }
+value-bag = { version = "=1.0.0-alpha.9", optional = true, default-features = false }
 
 [dev-dependencies]
 rustversion = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_test = "1.0"
 sval = { version = "=1.0.0-alpha.5", features = ["derive"] }
-value-bag = { version = "=1.0.0-alpha.8", features = ["test"] }
+value-bag = { version = "=1.0.0-alpha.9", features = ["test"] }

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -564,9 +564,7 @@ macro_rules! impl_value_to_primitive {
     }
 }
 
-impl_to_value_primitive![
-    usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32, f64, char, bool,
-];
+impl_to_value_primitive![usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32, f64, char, bool,];
 
 #[rustfmt::skip]
 impl_to_value_nonzero_primitive![

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -485,12 +485,14 @@ impl<'v> From<&'v i128> for Value<'v> {
 
 impl<'v> From<&'v std::num::NonZeroU128> for Value<'v> {
     fn from(v: &'v std::num::NonZeroU128) -> Value<'v> {
+        // SAFETY: `NonZeroU128` and `u128` have the same ABI
         Value::from_value_bag(unsafe { std::mem::transmute::<&std::num::NonZeroU128, &u128>(v) })
     }
 }
 
 impl<'v> From<&'v std::num::NonZeroI128> for Value<'v> {
     fn from(v: &'v std::num::NonZeroI128) -> Value<'v> {
+        // SAFETY: `NonZeroI128` and `i128` have the same ABI
         Value::from_value_bag(unsafe { std::mem::transmute::<&std::num::NonZeroI128, &i128>(v) })
     }
 }

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -441,9 +441,57 @@ impl ToValue for str {
     }
 }
 
+impl ToValue for u128 {
+    fn to_value(&self) -> Value {
+        Value::from(self)
+    }
+}
+
+impl ToValue for i128 {
+    fn to_value(&self) -> Value {
+        Value::from(self)
+    }
+}
+
+impl ToValue for std::num::NonZeroU128 {
+    fn to_value(&self) -> Value {
+        Value::from(self)
+    }
+}
+
+impl ToValue for std::num::NonZeroI128 {
+    fn to_value(&self) -> Value {
+        Value::from(self)
+    }
+}
+
 impl<'v> From<&'v str> for Value<'v> {
     fn from(value: &'v str) -> Self {
         Value::from_value_bag(value)
+    }
+}
+
+impl<'v> From<&'v u128> for Value<'v> {
+    fn from(value: &'v u128) -> Self {
+        Value::from_value_bag(value)
+    }
+}
+
+impl<'v> From<&'v i128> for Value<'v> {
+    fn from(value: &'v i128) -> Self {
+        Value::from_value_bag(value)
+    }
+}
+
+impl<'v> From<&'v std::num::NonZeroU128> for Value<'v> {
+    fn from(v: &'v std::num::NonZeroU128) -> Value<'v> {
+        Value::from_value_bag(unsafe { std::mem::transmute::<&std::num::NonZeroU128, &u128>(v) })
+    }
+}
+
+impl<'v> From<&'v std::num::NonZeroI128> for Value<'v> {
+    fn from(v: &'v std::num::NonZeroI128) -> Value<'v> {
+        Value::from_value_bag(unsafe { std::mem::transmute::<&std::num::NonZeroI128, &i128>(v) })
     }
 }
 
@@ -515,13 +563,13 @@ macro_rules! impl_value_to_primitive {
 }
 
 impl_to_value_primitive![
-    usize, u8, u16, u32, u64, u128, isize, i8, i16, i32, i64, i128, f32, f64, char, bool,
+    usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32, f64, char, bool,
 ];
 
 #[rustfmt::skip]
 impl_to_value_nonzero_primitive![
-    NonZeroUsize, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128,
-    NonZeroIsize, NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128,
+    NonZeroUsize, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64,
+    NonZeroIsize, NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64,
 ];
 
 impl_value_to_primitive![
@@ -617,12 +665,12 @@ pub trait Visit<'v> {
 
     /// Visit a big unsigned integer.
     fn visit_u128(&mut self, value: u128) -> Result<(), Error> {
-        self.visit_any(value.into())
+        self.visit_any((&value).into())
     }
 
     /// Visit a big signed integer.
     fn visit_i128(&mut self, value: i128) -> Result<(), Error> {
-        self.visit_any(value.into())
+        self.visit_any((&value).into())
     }
 
     /// Visit a floating point.

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -216,6 +216,28 @@ fn kv_string_keys() {
     all_log_macros!(target: "my_target", "also dogs" = "Fílos", "key/that-can't/be/an/ident" = "hi"; "hello {world}", world = "world");
 }
 
+#[test]
+#[cfg(feature = "kv_unstable")]
+fn kv_common_value_types() {
+    all_log_macros!(
+        u8 = 42u8,
+        u16 = 42u16,
+        u32 = 42u32,
+        u64 = 42u64,
+        u128 = 42u128,
+        i8 = -42i8,
+        i16 = -42i16,
+        i32 = -42i32,
+        i64 = -42i64,
+        i128 = -42i128,
+        f32 = 4.2f32,
+        f64 = -4.2f64,
+        bool = true,
+        str = "string";
+        "hello world"
+    );
+}
+
 /// Some and None (from Option) are used in the macros.
 #[derive(Debug)]
 enum Type {


### PR DESCRIPTION
This PR upgrades our `value-bag` version to `1.0.0-alpha.9`, which includes a breaking change to how 128bit numbers are handled. Instead of storing them by-value we only store them by reference. Along with some other internal layout changes this reduces the size of `Value` from 48 to 24 bytes, which is a great saving for the stack-local arrays we create to hold them.

In practice this doesn't affect whether or not 128bit values can be used in the macros because they rely on the `ToValue` trait, which is always by-reference. I'd be keen to hear if anybody is relying on the `From` impls though.

I'm hoping to get this through sooner rather than later in case https://github.com/rust-lang/rust/pull/95845 is merged in its current state that breaks constant type id comparison, which will mean shipping a patch to `value-bag` for `nightly` users.

r? @Thomasdezeeuw