### PR TITLE
Note that Log implementors should call enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1283,6 +1283,8 @@ pub trait Log: Sync + Send {
 
     /// Logs the `Record`.
     ///
+    /// # For implementors
+    ///
     /// Note that `enabled` is *not* necessarily called before this method.
     /// Implementations of `log` should perform all necessary filtering
     /// internally.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,6 +1273,12 @@ pub trait Log: Sync + Send {
     /// This is used by the `log_enabled!` macro to allow callers to avoid
     /// expensive computation of log message arguments if the message would be
     /// discarded anyway.
+    ///
+    /// # For implementors
+    ///
+    /// This method isn't called automatically by the `log!` macros.
+    /// It's up to an implementation of the `Log` trait to call `enabled` in its own
+    /// `log` method implementation to guarantee that filtering is applied.
     fn enabled(&self, metadata: &Metadata) -> bool;
 
     /// Logs the `Record`.


### PR DESCRIPTION
Closes #472

This just notes that implementors of the `Log` trait should call their own `enabled` function somewhere in their `log` implementation to apply filtering.