### PR TITLE
Prepare for 0.4.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.17] - 2022-04-29
+
+* Update `kv_unstable` internal dependencies.
+
 ## [0.4.16] - 2022-03-22
 
 * Fix a conflict with unqualified `Option` use in macros.
@@ -215,7 +219,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.16...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.17...HEAD
+[0.4.17]: https://github.com/rust-lang-nursery/log/compare/0.4.16...0.4.17
 [0.4.16]: https://github.com/rust-lang-nursery/log/compare/0.4.15...0.4.16
 [0.4.15]: https://github.com/rust-lang-nursery/log/compare/0.4.13...0.4.15
 [0.4.14]: https://github.com/rust-lang-nursery/log/compare/0.4.13...0.4.14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.16" # remember to update html_root_url
+version = "0.4.17" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.16"
+    html_root_url = "https://docs.rs/log/0.4.17"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
[Changes since the last release](https://github.com/rust-lang/log/compare/3cc17c1c4f...master)

Includes:

- #502 
- #504 
- #505 
- #506