### PR TITLE
fix markdown links (again)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,6 +309,7 @@
 //! [systemd-journal-logger]: https://docs.rs/systemd-journal-logger/*/systemd_journal_logger/
 //! [android_log]: https://docs.rs/android_log/*/android_log/
 //! [win_dbg_logger]: https://docs.rs/win_dbg_logger/*/win_dbg_logger/
+//! [db_logger]: https://docs.rs/db_logger/*/db_logger/
 //! [console_log]: https://docs.rs/console_log/*/console_log/
 
 #![doc(


### PR DESCRIPTION
Maybe `cargo doc` should be added to CI, because then this should have been catched:

```text
# cargo doc
    Updating crates.io index
   Compiling log v0.4.17 (/tmp/tmp.27i2Wggps5)
 Documenting cfg-if v1.0.0
    Checking cfg-if v1.0.0
 Documenting log v0.4.17 (/tmp/tmp.27i2Wggps5)
warning: unresolved link to `db_logger`
   --> src/lib.rs:148:12
    |
148 | //!     * [db_logger]
    |            ^^^^^^^^^ no item named `db_logger` in scope
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
```

together with `#![deny(rustdoc::broken_intra_doc_links)]` ? :)