### PR TITLE
Move `lvl <= $crate::max_level()` inside called functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1588,22 +1588,24 @@ pub fn __private_api_log(
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
     kvs: Option<&[(&str, &str)]>,
 ) {
-    if kvs.is_some() {
-        panic!(
-            "key-value support is experimental and must be enabled using the `kv_unstable` feature"
-        )
-    }
+    if level <= max_level() {
+        if kvs.is_some() {
+            panic!(
+                "key-value support is experimental and must be enabled using the `kv_unstable` feature"
+            )
+        }
 
-    logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .build(),
-    );
+        logger().log(
+            &Record::builder()
+                .args(args)
+                .level(level)
+                .target(target)
+                .module_path_static(Some(module_path))
+                .file_static(Some(file))
+                .line(Some(line))
+                .build(),
+        );
+    }
 }
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
@@ -1615,23 +1617,26 @@ pub fn __private_api_log(
     &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
     kvs: Option<&[(&str, &dyn kv::ToValue)]>,
 ) {
-    logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .key_values(&kvs)
-            .build(),
-    );
+    if level <= max_level() {
+        logger().log(
+            &Record::builder()
+                .args(args)
+                .level(level)
+                .target(target)
+                .module_path_static(Some(module_path))
+                .file_static(Some(file))
+                .line(Some(line))
+                .key_values(&kvs)
+                .build(),
+        );
+    }
 }
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
 #[doc(hidden)]
 pub fn __private_api_enabled(level: Level, target: &str) -> bool {
-    logger().enabled(&Metadata::builder().level(level).target(target).build())
+    level <= max_level()
+        && logger().enabled(&Metadata::builder().level(level).target(target).build())
 }
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,7 +32,7 @@ macro_rules! log {
     // log!(target: "my_target", Level::Info; key1 = 42, key2 = true; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($key:tt = $value:expr),+; $($arg:tt)+) => ({
         let lvl = $lvl;
-        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+        if lvl <= $crate::STATIC_MAX_LEVEL {
             $crate::__private_api_log(
                 __log_format_args!($($arg)+),
                 lvl,
@@ -45,7 +45,7 @@ macro_rules! log {
     // log!(target: "my_target", Level::Info; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
-        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+        if lvl <= $crate::STATIC_MAX_LEVEL {
             $crate::__private_api_log(
                 __log_format_args!($($arg)+),
                 lvl,
@@ -215,9 +215,7 @@ macro_rules! trace {
 macro_rules! log_enabled {
     (target: $target:expr, $lvl:expr) => {{
         let lvl = $lvl;
-        lvl <= $crate::STATIC_MAX_LEVEL
-            && lvl <= $crate::max_level()
-            && $crate::__private_api_enabled(lvl, $target)
+        lvl <= $crate::STATIC_MAX_LEVEL && $crate::__private_api_enabled(lvl, $target)
     }};
     ($lvl:expr) => {
         log_enabled!(target: __log_module_path!(), $lvl)


### PR DESCRIPTION
This change will reduce binary size at the cost of some performance loss.