### PR TITLE
Make `Level` and `LevelFilter` usable in clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["rfcs/**/*"]
 build = "build.rs"
 
 [package.metadata.docs.rs]
-features = ["std", "serde", "kv_unstable_std", "kv_unstable_sval", "kv_unstable_serde"]
+features = ["std", "serde", "clap", "kv_unstable_std", "kv_unstable_sval", "kv_unstable_serde"]
 
 [[test]]
 name = "filters"
@@ -51,12 +51,14 @@ kv_unstable = ["value-bag"]
 kv_unstable_sval = ["kv_unstable", "value-bag/sval", "sval"]
 kv_unstable_std = ["std", "kv_unstable", "value-bag/error"]
 kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]
+use_clap = ["std", "clap"]
 
 [dependencies]
 cfg-if = "1.0"
 serde = { version = "1.0", optional = true, default-features = false }
 sval = { version = "=1.0.0-alpha.5", optional = true, default-features = false }
 value-bag = { version = "=1.0.0-alpha.9", optional = true, default-features = false }
+clap = { version = "3.2", optional = true, default-features = false, features = ["derive", "std"] }
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,7 @@ static LEVEL_PARSE_ERROR: &str =
 /// [`LevelFilter`](enum.LevelFilter.html).
 #[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(all(feature = "clap", feature = "std"), derive(clap::ValueEnum))]
 pub enum Level {
     /// The "error" level.
     ///
@@ -552,6 +553,7 @@ impl Level {
 /// [`set_max_level`]: fn.set_max_level.html
 #[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(all(feature = "clap", feature = "std"), derive(clap::ValueEnum))]
 pub enum LevelFilter {
     /// A level lower than all log levels.
     Off,


### PR DESCRIPTION
Allow log level enums to be used in clap.

Typical usage: 

```rust
#[derive(clap::Parser)]
struct Opt {
    #[clap(short, long, default_value = "info")]
    log_level: LevelFilter,
}
```