### PR TITLE
Add Arbitrary Trait To RecordBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ cfg-if = "1.0"
 serde = { version = "1.0", optional = true, default-features = false }
 sval = { version = "=1.0.0-alpha.5", optional = true, default-features = false }
 value-bag = { version = "=1.0.0-alpha.9", optional = true, default-features = false }
+arbitrary = {version = "1.1.6", optional = true, features = ["derive"]}
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/src/arbitrary_impl.rs
+++ b/src/arbitrary_impl.rs
@@ -1,0 +1,49 @@
+use crate::{Level, MetadataBuilder, RecordBuilder};
+use arbitrary::{Arbitrary, Result, Unstructured};
+
+impl<'a> Arbitrary<'a> for RecordBuilder<'a> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let target = &<&'a str>::arbitrary(u)?;
+        let path = <&'a str>::arbitrary(u)?;
+        let file = <&'a str>::arbitrary(u)?;
+
+        let mut builder = RecordBuilder::new();
+
+        builder
+            // We can't yet provide an arbitrary fmt::Argument object because
+            // the output of format_args! must be consumed where it is called.
+            // It cannot be bound to a variable. See https://github.com/rust-lang/rust/issues/92698#ref-pullrequest-1225460272
+            // .args(format_args!("{}", logoutput))
+            .metadata(
+                MetadataBuilder::new()
+                    .level(Level::arbitrary(u)?)
+                    .target(target)
+                    .build(),
+            )
+            .file(Some(file.clone()))
+            .line(Option::<u32>::arbitrary(u)?)
+            .module_path(Some(path.clone()));
+
+        return Ok(builder);
+    }
+}
+#[cfg(test)]
+mod tests {
+    use crate::{logger, RecordBuilder};
+    use arbitrary::{Arbitrary, Unstructured};
+
+    #[derive(Arbitrary, Debug)]
+    struct LogFuzzerInput<'a> {
+        builder: RecordBuilder<'a>,
+        message: String,
+    }
+
+    #[test]
+    fn arbitrary_record() {
+        let input: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut buf = Unstructured::new(&input);
+        let mut arb = LogFuzzerInput::arbitrary(&mut buf).unwrap();
+
+        logger().log(&arb.builder.args(format_args!("{}", arb.message)).build());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,12 @@
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
+
+#[cfg(feature = "arbitrary")]
+mod arbitrary_impl;
+#[cfg(feature = "arbitrary")]
+extern crate arbitrary;
+
 #[macro_use]
 extern crate cfg_if;
 
@@ -423,6 +429,7 @@ static LEVEL_PARSE_ERROR: &str =
 /// [`LevelFilter`](enum.LevelFilter.html).
 #[repr(usize)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Level {
     /// The "error" level.
     ///
@@ -551,6 +558,7 @@ impl Level {
 /// [`max_level()`]: fn.max_level.html
 /// [`set_max_level`]: fn.set_max_level.html
 #[repr(usize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum LevelFilter {
     /// A level lower than all log levels.
@@ -724,6 +732,8 @@ pub struct Record<'a> {
     #[cfg(feature = "kv_unstable")]
     key_values: KeyValues<'a>,
 }
+
+
 
 // This wrapper type is only needed so we can
 // `#[derive(Debug)]` on `Record`. It also


### PR DESCRIPTION
This is an optional dependency, enabled with cargo flag `--feature arbitrary,std` that allows for fuzzing of loggers with much less boilerplate than was previously required.

An example of usage would be

```
use log::RecordBuilder;
use arbitrary::Arbitrary;
use libfuzzer::
use libfuzzer_sys::fuzz_target;

#[derive(Arbitrary, Debug)]
struct FuzzerInput {
  builder: RecordBuilder,
  message: String,
}

fuzz_target!(|input: &FuzzerInput| {
  let logger = MyLogger();
  logger.log(&input.builder.args(format_args!("{}", message)).build())
});

```

Note that if there is ever progress on a more flexible `format_args!` as described in https://github.com/rust-lang/rust/issues/92698#ref-pullrequest-1225460272 then this could be simplified even further and we could provide an `Arbitrary` implementation of `Record` itself.