### PR TITLE
Remove dependency on cfg_if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ kv_unstable_std = ["std", "kv_unstable", "value-bag/error"]
 kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]
 
 [dependencies]
-cfg-if = "1.0"
 serde = { version = "1.0", optional = true, default-features = false }
 sval = { version = "=1.0.0-alpha.5", optional = true, default-features = false }
 value-bag = { version = "=1.0.0-alpha.9", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1504,34 +1504,59 @@ pub mod __private_api {
 /// [`logger`]: fn.logger.html
 pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL_INNER;
 
-#[rustfmt::skip]
-const MAX_LEVEL_INNER: LevelFilter = {
-    if cfg!(all(not(debug_assertions), feature = "release_max_level_off")) {
-        LevelFilter::Off
-    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_error")) {
-        LevelFilter::Error
-    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_warn")) {
-        LevelFilter::Warn
-    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_info")) {
-        LevelFilter::Info
-    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_debug")) {
-        LevelFilter::Debug
-    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_trace")) {
-        LevelFilter::Trace
-    } else if cfg!(feature = "max_level_off") {
-        LevelFilter::Off
-    } else if cfg!(feature = "max_level_error") {
-        LevelFilter::Error
-    } else if cfg!(feature = "max_level_warn") {
-        LevelFilter::Warn
-    } else if cfg!(feature = "max_level_info") {
-        LevelFilter::Info
-    } else if cfg!(feature = "max_level_debug") {
-        LevelFilter::Debug
-    } else {
+const MAX_LEVEL_INNER: LevelFilter = get_max_level_inner();
+
+const fn get_max_level_inner() -> LevelFilter {
+    #[allow(unreachable_code)]
+    {
+        #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))]
+        {
+            return LevelFilter::Off;
+        }
+        #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))]
+        {
+            return LevelFilter::Error;
+        }
+        #[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))]
+        {
+            return LevelFilter::Warn;
+        }
+        #[cfg(all(not(debug_assertions), feature = "release_max_level_info"))]
+        {
+            return LevelFilter::Info;
+        }
+        #[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))]
+        {
+            return LevelFilter::Debug;
+        }
+        #[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))]
+        {
+            return LevelFilter::Trace;
+        }
+        #[cfg(feature = "max_level_off")]
+        {
+            return LevelFilter::Off;
+        }
+        #[cfg(feature = "max_level_error")]
+        {
+            return LevelFilter::Error;
+        }
+        #[cfg(feature = "max_level_warn")]
+        {
+            return LevelFilter::Warn;
+        }
+        #[cfg(feature = "max_level_info")]
+        {
+            return LevelFilter::Info;
+        }
+        #[cfg(feature = "max_level_debug")]
+        {
+            return LevelFilter::Debug;
+        }
+
         LevelFilter::Trace
     }
-};
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,9 +328,6 @@
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
-#[macro_use]
-extern crate cfg_if;
-
 use std::cmp;
 #[cfg(feature = "std")]
 use std::error;
@@ -1507,33 +1504,34 @@ pub mod __private_api {
 /// [`logger`]: fn.logger.html
 pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL_INNER;
 
-cfg_if! {
-    if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Off;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Error;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Warn;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_info"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Info;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Debug;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Trace;
-    } else if #[cfg(feature = "max_level_off")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Off;
-    } else if #[cfg(feature = "max_level_error")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Error;
-    } else if #[cfg(feature = "max_level_warn")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Warn;
-    } else if #[cfg(feature = "max_level_info")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Info;
-    } else if #[cfg(feature = "max_level_debug")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Debug;
+#[rustfmt::skip]
+const MAX_LEVEL_INNER: LevelFilter = {
+    if cfg!(all(not(debug_assertions), feature = "release_max_level_off")) {
+        LevelFilter::Off
+    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_error")) {
+        LevelFilter::Error
+    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_warn")) {
+        LevelFilter::Warn
+    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_info")) {
+        LevelFilter::Info
+    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_debug")) {
+        LevelFilter::Debug
+    } else if cfg!(all(not(debug_assertions), feature = "release_max_level_trace")) {
+        LevelFilter::Trace
+    } else if cfg!(feature = "max_level_off") {
+        LevelFilter::Off
+    } else if cfg!(feature = "max_level_error") {
+        LevelFilter::Error
+    } else if cfg!(feature = "max_level_warn") {
+        LevelFilter::Warn
+    } else if cfg!(feature = "max_level_info") {
+        LevelFilter::Info
+    } else if cfg!(feature = "max_level_debug") {
+        LevelFilter::Debug
     } else {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Trace;
+        LevelFilter::Trace
     }
-}
+};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
`cfg_if` is only used in a single place and seems a bit redundant.

log is such a depended upon library I feel like removing even the smallest dependency is a win