### PR TITLE
Add call_logger to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ There are many available implementations to choose from, here are some of the mo
     * [`pretty_env_logger`](https://docs.rs/pretty_env_logger/*/pretty_env_logger/)
     * [`stderrlog`](https://docs.rs/stderrlog/*/stderrlog/)
     * [`flexi_logger`](https://docs.rs/flexi_logger/*/flexi_logger/)
+    * [`call_logger`](https://docs.rs/call_logger/*/call_logger/)
 * Complex configurable frameworks:
     * [`log4rs`](https://docs.rs/log4rs/*/log4rs/)
     * [`fern`](https://docs.rs/fern/*/fern/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@
 //!     * [pretty_env_logger]
 //!     * [stderrlog]
 //!     * [flexi_logger]
+//!     * [call_logger]
 //! * Complex configurable frameworks:
 //!     * [log4rs]
 //!     * [fern]
@@ -302,6 +303,7 @@
 //! [pretty_env_logger]: https://docs.rs/pretty_env_logger/*/pretty_env_logger/
 //! [stderrlog]: https://docs.rs/stderrlog/*/stderrlog/
 //! [flexi_logger]: https://docs.rs/flexi_logger/*/flexi_logger/
+//! [call_logger]: https://docs.rs/call_logger/*/call_logger/
 //! [syslog]: https://docs.rs/syslog/*/syslog/
 //! [slog-stdlog]: https://docs.rs/slog-stdlog/*/slog_stdlog/
 //! [log4rs]: https://docs.rs/log4rs/*/log4rs/


### PR DESCRIPTION
Add links to compatible  [call_logger](https://docs.rs/call_logger/0.0.2/call_logger/) to the README and rustdoc documentation