### PR TITLE
Add std-logger to list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ There are many available implementations to choose from, here are some of the mo
     * [`stderrlog`](https://docs.rs/stderrlog/*/stderrlog/)
     * [`flexi_logger`](https://docs.rs/flexi_logger/*/flexi_logger/)
     * [`call_logger`](https://docs.rs/call_logger/*/call_logger/)
+    * [`std-logger`](https://docs.rs/std-logger/*/std-logger/)
 * Complex configurable frameworks:
     * [`log4rs`](https://docs.rs/log4rs/*/log4rs/)
     * [`fern`](https://docs.rs/fern/*/fern/)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ There are many available implementations to choose from, here are some of the mo
     * [`stderrlog`](https://docs.rs/stderrlog/*/stderrlog/)
     * [`flexi_logger`](https://docs.rs/flexi_logger/*/flexi_logger/)
     * [`call_logger`](https://docs.rs/call_logger/*/call_logger/)
-    * [`std-logger`](https://docs.rs/std-logger/*/std-logger/)
+    * [`std-logger`](https://docs.rs/std-logger/*/std_logger/)
 * Complex configurable frameworks:
     * [`log4rs`](https://docs.rs/log4rs/*/log4rs/)
     * [`fern`](https://docs.rs/fern/*/fern/)


### PR DESCRIPTION
While making https://github.com/rust-lang/log/pull/553 I released my own library isn't even in the list, so I though I might as well add it. Unless we decide to remove all of them in https://github.com/rust-lang/log/issues/551.