### PR TITLE
[doc] src/lib.rs : prefix an unused variable with an underscore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,7 +690,7 @@ impl<'a> MaybeStaticStr<'a> {
 /// struct SimpleLogger;
 ///
 /// impl log::Log for SimpleLogger {
-///    fn enabled(&self, metadata: &log::Metadata) -> bool {
+///    fn enabled(&self, _metadata: &log::Metadata) -> bool {
 ///        true
 ///    }
 ///


### PR DESCRIPTION
unused variable: `metadata`,  according to rustc, 
if this is intentional, prefix it with an underscore: `_metadata`