### PR TITLE
[doc] src/macros.rs :  correct  grammar errors of an example in lib documentation

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! log {
-    // log!(target: "my_target", Level::Info; key1 = 42, key2 = true; "a {} event", "log");
+    // log!(target: "my_target", Level::Info, key1 = 42, key2 = true; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($key:tt = $value:expr),+; $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
@@ -42,7 +42,7 @@ macro_rules! log {
         }
     });
 
-    // log!(target: "my_target", Level::Info; "a {} event", "log");
+    // log!(target: "my_target", Level::Info, "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {


### PR DESCRIPTION
change semicolons to commas
   