### PR TITLE
Revert MSRV bump for patch release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,11 +127,8 @@ jobs:
       - uses: actions/checkout@master
       - name: Install Rust
         run: |
-          rustup update 1.60.0 --no-self-update
-          rustup default 1.60.0
-      - run: cargo build --verbose
-      - run: cargo build --verbose --features serde
-      - run: cargo build --verbose --features std
+          rustup update 1.31.0 --no-self-update
+          rustup default 1.31.0
       - run: cargo test --verbose --manifest-path tests/Cargo.toml
 
   embedded:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ A lightweight logging facade for Rust
 categories = ["development-tools::debugging"]
 keywords = ["logging"]
 exclude = ["rfcs/**/*"]
-rust-version = "1.60.0"
+build = "build.rs"
 
 [package.metadata.docs.rs]
 features = ["std", "serde", "kv_unstable_std", "kv_unstable_sval", "kv_unstable_serde"]
@@ -56,7 +56,7 @@ kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]
 serde = { version = "1.0", optional = true, default-features = false }
 sval = { version = "2.1", optional = true, default-features = false }
 sval_ref = { version = "2.1", optional = true, default-features = false }
-value-bag = { version = "1.1", optional = true, default-features = false }
+value-bag = { version = "1.4", optional = true, default-features = false }
 
 [dev-dependencies]
 rustversion = "1.0"
@@ -64,4 +64,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_test = "1.0"
 sval = { version = "2.1" }
 sval_derive = { version = "2.1" }
-value-bag = { version = "1.1", features = ["test"] }
+value-bag = { version = "1.4", features = ["test"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,46 @@
+//! This build script detects target platforms that lack proper support for
+//! atomics and sets `cfg` flags accordingly.
+
+use std::env;
+use std::str;
+
+fn main() {
+    let target = match rustc_target() {
+        Some(target) => target,
+        None => return,
+    };
+
+    if target_has_atomic_cas(&target) {
+        println!("cargo:rustc-cfg=atomic_cas");
+    }
+
+    if target_has_atomics(&target) {
+        println!("cargo:rustc-cfg=has_atomics");
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn target_has_atomic_cas(target: &str) -> bool {
+    match target {
+        "thumbv6m-none-eabi"
+        | "msp430-none-elf"
+        | "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf" => false,
+        _ => true,
+    }
+}
+
+fn target_has_atomics(target: &str) -> bool {
+    match target {
+        "thumbv4t-none-eabi"
+        | "msp430-none-elf"
+        | "riscv32i-unknown-none-elf"
+        | "riscv32imc-unknown-none-elf" => false,
+        _ => true,
+    }
+}
+
+fn rustc_target() -> Option<String> {
+    env::var("TARGET").ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,20 +344,20 @@ mod serde;
 #[cfg(feature = "kv_unstable")]
 pub mod kv;
 
-#[cfg(target_has_atomic = "ptr")]
+#[cfg(has_atomics)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[cfg(not(target_has_atomic = "ptr"))]
+#[cfg(not(has_atomics))]
 use std::cell::Cell;
-#[cfg(not(target_has_atomic = "ptr"))]
+#[cfg(not(has_atomics))]
 use std::sync::atomic::Ordering;
 
-#[cfg(not(target_has_atomic = "ptr"))]
+#[cfg(not(has_atomics))]
 struct AtomicUsize {
     v: Cell<usize>,
 }
 
-#[cfg(not(target_has_atomic = "ptr"))]
+#[cfg(not(has_atomics))]
 impl AtomicUsize {
     const fn new(v: usize) -> AtomicUsize {
         AtomicUsize { v: Cell::new(v) }
@@ -371,7 +371,7 @@ impl AtomicUsize {
         self.v.set(val)
     }
 
-    #[cfg(target_has_atomic = "ptr")]
+    #[cfg(atomic_cas)]
     fn compare_exchange(
         &self,
         current: usize,
@@ -389,7 +389,7 @@ impl AtomicUsize {
 
 // Any platform without atomics is unlikely to have multiple cores, so
 // writing via Cell will not be a race condition.
-#[cfg(not(target_has_atomic = "ptr"))]
+#[cfg(not(has_atomics))]
 unsafe impl Sync for AtomicUsize {}
 
 // The LOGGER static holds a pointer to the global logger. It is protected by
@@ -1217,7 +1217,6 @@ where
 ///
 /// Note that `Trace` is the maximum level, because it provides the maximum amount of detail in the emitted logs.
 #[inline]
-#[cfg(target_has_atomic = "ptr")]
 pub fn set_max_level(level: LevelFilter) {
     MAX_LOG_LEVEL_FILTER.store(level as usize, Ordering::Relaxed);
 }
@@ -1286,7 +1285,7 @@ pub fn max_level() -> LevelFilter {
 /// An error is returned if a logger has already been set.
 ///
 /// [`set_logger`]: fn.set_logger.html
-#[cfg(all(feature = "std", target_has_atomic = "ptr"))]
+#[cfg(all(feature = "std", atomic_cas))]
 pub fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), SetLoggerError> {
     set_logger_inner(|| Box::leak(logger))
 }
@@ -1344,12 +1343,12 @@ pub fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), SetLoggerError> {
 /// ```
 ///
 /// [`set_logger_racy`]: fn.set_logger_racy.html
-#[cfg(target_has_atomic = "ptr")]
+#[cfg(atomic_cas)]
 pub fn set_logger(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
     set_logger_inner(|| logger)
 }
 
-#[cfg(target_has_atomic = "ptr")]
+#[cfg(atomic_cas)]
 fn set_logger_inner<F>(make_logger: F) -> Result<(), SetLoggerError>
 where
     F: FnOnce() -> &'static dyn Log,


### PR DESCRIPTION
For #564

This is already fixed on the `master` branch, but we committed not to release that until the next stable version of Debian. In the meantime, this reverts #543 so we can get a patch out that still targets `rustc` `1.31.0`. Once that is released, I'll revert this commit so #552 will still include it.