### PR TITLE
Remove `local_inner_macros` usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1523,6 +1523,7 @@ pub fn __private_api_enabled(level: Level, target: &str) -> bool {
 #[doc(hidden)]
 pub mod __private_api {
     pub use std::option::Option;
+    pub use std::{file, format_args, line, module_path, stringify};
 }
 
 /// The statically resolved maximum log level.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,17 +27,17 @@
 ///     data.0, data.1, private_data);
 /// # }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! log {
     // log!(target: "my_target", Level::Info, key1 = 42, key2 = true; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($key:tt = $value:expr),+; $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log(
-                __log_format_args!($($arg)+),
+                $crate::__private_api::format_args!($($arg)+),
                 lvl,
-                &($target, __log_module_path!(), __log_file!(), __log_line!()),
-                $crate::__private_api::Option::Some(&[$((__log_key!($key), &$value)),+])
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!(), $crate::__private_api::line!()),
+                $crate::__private_api::Option::Some(&[$(($crate::__log_key!($key), &$value)),+])
             );
         }
     });
@@ -47,16 +47,16 @@ macro_rules! log {
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::__private_api_log(
-                __log_format_args!($($arg)+),
+                $crate::__private_api::format_args!($($arg)+),
                 lvl,
-                &($target, __log_module_path!(), __log_file!(), __log_line!()),
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!(), $crate::__private_api::line!()),
                 $crate::__private_api::Option::None,
             );
         }
     });
 
     // log!(Level::Info, "a log event")
-    ($lvl:expr, $($arg:tt)+) => (log!(target: __log_module_path!(), $lvl, $($arg)+));
+    ($lvl:expr, $($arg:tt)+) => ($crate::log!(target: $crate::__private_api::module_path!(), $lvl, $($arg)+));
 }
 
 /// Logs a message at the error level.
@@ -73,14 +73,14 @@ macro_rules! log {
 /// error!(target: "app_events", "App Error: {}, Port: {}", err_info, 22);
 /// # }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! error {
     // error!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // error!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log!(target: $target, $crate::Level::Error, $($arg)+));
+    (target: $target:expr, $($arg:tt)+) => ($crate::log!(target: $target, $crate::Level::Error, $($arg)+));
 
     // error!("a {} event", "log")
-    ($($arg:tt)+) => (log!($crate::Level::Error, $($arg)+))
+    ($($arg:tt)+) => ($crate::log!($crate::Level::Error, $($arg)+))
 }
 
 /// Logs a message at the warn level.
@@ -97,14 +97,14 @@ macro_rules! error {
 /// warn!(target: "input_events", "App received warning: {}", warn_description);
 /// # }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! warn {
     // warn!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // warn!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log!(target: $target, $crate::Level::Warn, $($arg)+));
+    (target: $target:expr, $($arg:tt)+) => ($crate::log!(target: $target, $crate::Level::Warn, $($arg)+));
 
     // warn!("a {} event", "log")
-    ($($arg:tt)+) => (log!($crate::Level::Warn, $($arg)+))
+    ($($arg:tt)+) => ($crate::log!($crate::Level::Warn, $($arg)+))
 }
 
 /// Logs a message at the info level.
@@ -123,14 +123,14 @@ macro_rules! warn {
 ///       conn_info.port, conn_info.speed);
 /// # }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! info {
     // info!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // info!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log!(target: $target, $crate::Level::Info, $($arg)+));
+    (target: $target:expr, $($arg:tt)+) => ($crate::log!(target: $target, $crate::Level::Info, $($arg)+));
 
     // info!("a {} event", "log")
-    ($($arg:tt)+) => (log!($crate::Level::Info, $($arg)+))
+    ($($arg:tt)+) => ($crate::log!($crate::Level::Info, $($arg)+))
 }
 
 /// Logs a message at the debug level.
@@ -148,14 +148,14 @@ macro_rules! info {
 /// debug!(target: "app_events", "New position: x: {}, y: {}", pos.x, pos.y);
 /// # }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! debug {
     // debug!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // debug!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log!(target: $target, $crate::Level::Debug, $($arg)+));
+    (target: $target:expr, $($arg:tt)+) => ($crate::log!(target: $target, $crate::Level::Debug, $($arg)+));
 
     // debug!("a {} event", "log")
-    ($($arg:tt)+) => (log!($crate::Level::Debug, $($arg)+))
+    ($($arg:tt)+) => ($crate::log!($crate::Level::Debug, $($arg)+))
 }
 
 /// Logs a message at the trace level.
@@ -175,14 +175,14 @@ macro_rules! debug {
 ///        if pos.y >= 0.0 { "positive" } else { "negative" });
 /// # }
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! trace {
     // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // trace!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log!(target: $target, $crate::Level::Trace, $($arg)+));
+    (target: $target:expr, $($arg:tt)+) => ($crate::log!(target: $target, $crate::Level::Trace, $($arg)+));
 
     // trace!("a {} event", "log")
-    ($($arg:tt)+) => (log!($crate::Level::Trace, $($arg)+))
+    ($($arg:tt)+) => ($crate::log!($crate::Level::Trace, $($arg)+))
 }
 
 /// Determines if a message logged at the specified level in that module will
@@ -211,7 +211,7 @@ macro_rules! trace {
 /// # fn expensive_call() -> Data { Data { x: 0, y: 0 } }
 /// # fn main() {}
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! log_enabled {
     (target: $target:expr, $lvl:expr) => {{
         let lvl = $lvl;
@@ -220,49 +220,7 @@ macro_rules! log_enabled {
             && $crate::__private_api_enabled(lvl, $target)
     }};
     ($lvl:expr) => {
-        log_enabled!(target: __log_module_path!(), $lvl)
-    };
-}
-
-// The log macro above cannot invoke format_args directly because it uses
-// local_inner_macros. A format_args invocation there would resolve to
-// $crate::format_args which does not exist. Instead invoke format_args here
-// outside of local_inner_macros so that it resolves (probably) to
-// core::format_args or std::format_args. Same for the several macros that
-// follow.
-//
-// This is a workaround until we drop support for pre-1.30 compilers. At that
-// point we can remove use of local_inner_macros, use $crate:: when invoking
-// local macros, and invoke format_args directly.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __log_format_args {
-    ($($args:tt)*) => {
-        format_args!($($args)*)
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __log_module_path {
-    () => {
-        module_path!()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __log_file {
-    () => {
-        file!()
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __log_line {
-    () => {
-        line!()
+        $crate::log_enabled!(target: $crate::__private_api::module_path!(), $lvl)
     };
 }
 
@@ -271,7 +229,7 @@ macro_rules! __log_line {
 macro_rules! __log_key {
     // key1 = 42
     ($($args:ident)*) => {
-        stringify!($($args)*)
+        $crate::__private_api::stringify!($($args)*)
     };
     // "key1" = 42
     ($($args:expr)*) => {


### PR DESCRIPTION
Since we have dropped support for pre-1.30 compilers.