### PR TITLE
doc: Add log-to-defmt to other-facilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ There are many available implementations to choose from, here are some options:
     * [`android_log`](https://docs.rs/android_log/*/android_log/)
     * [`win_dbg_logger`](https://docs.rs/win_dbg_logger/*/win_dbg_logger/)
     * [`db_logger`](https://docs.rs/db_logger/*/db_logger/)
+    * [`log-to-defmt`](https://docs.rs/log-to-defmt/*/log_to_defmt/)
 * For WebAssembly binaries:
     * [`console_log`](https://docs.rs/console_log/*/console_log/)
 * For dynamic libraries:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@
 //!     * [android_log]
 //!     * [win_dbg_logger]
 //!     * [db_logger]
+//!     * [log-to-defmt]
 //! * For WebAssembly binaries:
 //!     * [console_log]
 //! * For dynamic libraries:
@@ -313,6 +314,7 @@
 //! [android_log]: https://docs.rs/android_log/*/android_log/
 //! [win_dbg_logger]: https://docs.rs/win_dbg_logger/*/win_dbg_logger/
 //! [db_logger]: https://docs.rs/db_logger/*/db_logger/
+//! [log-to-defmt]: https://docs.rs/log-to-defmt/*/log_to_defmt/
 //! [console_log]: https://docs.rs/console_log/*/console_log/
 //! [structured-logger]: https://docs.rs/structured-logger/latest/structured_logger/
 


### PR DESCRIPTION
This adds a crate I've written and been using occasionally.

It's not something recommended for general use (its README explains the caveats; tl;dr: defmt benefits are gone once used with log), but when someone is on a defmt platform and briefly needs to capture a logging crate reports, this list is probably where they're looking.