### PR TITLE
Group `target_module`, `path` and `file` arguments

### DIFF
--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -1,0 +1,55 @@
+//! WARNING: this is not part of the crate's public API and is subject to change at any time
+
+use crate::{Level, Metadata, Record};
+use std::fmt::Arguments;
+pub use std::option::Option;
+pub use std::{file, format_args, line, module_path, stringify};
+
+#[cfg(not(feature = "kv_unstable"))]
+pub fn log(
+    args: Arguments,
+    level: Level,
+    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+    kvs: Option<&[(&str, &str)]>,
+) {
+    if kvs.is_some() {
+        panic!(
+            "key-value support is experimental and must be enabled using the `kv_unstable` feature"
+        )
+    }
+
+    crate::logger().log(
+        &Record::builder()
+            .args(args)
+            .level(level)
+            .target(target)
+            .module_path_static(Some(module_path))
+            .file_static(Some(file))
+            .line(Some(line))
+            .build(),
+    );
+}
+
+#[cfg(feature = "kv_unstable")]
+pub fn log(
+    args: Arguments,
+    level: Level,
+    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+    kvs: Option<&[(&str, &dyn crate::kv::ToValue)]>,
+) {
+    crate::logger().log(
+        &Record::builder()
+            .args(args)
+            .level(level)
+            .target(target)
+            .module_path_static(Some(module_path))
+            .file_static(Some(file))
+            .line(Some(line))
+            .key_values(&kvs)
+            .build(),
+    );
+}
+
+pub fn enabled(level: Level, target: &str) -> bool {
+    crate::logger().enabled(&Metadata::builder().level(level).target(target).build())
+}

--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -9,7 +9,8 @@ pub use std::{file, format_args, line, module_path, stringify};
 pub fn log(
     args: Arguments,
     level: Level,
-    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+    &(target, module_path, file): &(&str, &'static str, &'static str),
+    line: u32,
     kvs: Option<&[(&str, &str)]>,
 ) {
     if kvs.is_some() {
@@ -34,7 +35,8 @@ pub fn log(
 pub fn log(
     args: Arguments,
     level: Level,
-    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
+    &(target, module_path, file): &(&str, &'static str, &'static str),
+    line: u32,
     kvs: Option<&[(&str, &dyn crate::kv::ToValue)]>,
 ) {
     crate::logger().log(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1466,65 +1466,7 @@ pub fn logger() -> &'static dyn Log {
 
 // WARNING: this is not part of the crate's public API and is subject to change at any time
 #[doc(hidden)]
-#[cfg(not(feature = "kv_unstable"))]
-pub fn __private_api_log(
-    args: fmt::Arguments,
-    level: Level,
-    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &str)]>,
-) {
-    if kvs.is_some() {
-        panic!(
-            "key-value support is experimental and must be enabled using the `kv_unstable` feature"
-        )
-    }
-
-    logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .build(),
-    );
-}
-
-// WARNING: this is not part of the crate's public API and is subject to change at any time
-#[doc(hidden)]
-#[cfg(feature = "kv_unstable")]
-pub fn __private_api_log(
-    args: fmt::Arguments,
-    level: Level,
-    &(target, module_path, file, line): &(&str, &'static str, &'static str, u32),
-    kvs: Option<&[(&str, &dyn kv::ToValue)]>,
-) {
-    logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .key_values(&kvs)
-            .build(),
-    );
-}
-
-// WARNING: this is not part of the crate's public API and is subject to change at any time
-#[doc(hidden)]
-pub fn __private_api_enabled(level: Level, target: &str) -> bool {
-    logger().enabled(&Metadata::builder().level(level).target(target).build())
-}
-
-// WARNING: this is not part of the crate's public API and is subject to change at any time
-#[doc(hidden)]
-pub mod __private_api {
-    pub use std::option::Option;
-    pub use std::{file, format_args, line, module_path, stringify};
-}
+pub mod __private_api;
 
 /// The statically resolved maximum log level.
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! log {
     (target: $target:expr, $lvl:expr, $($key:tt = $value:expr),+; $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
-            $crate::__private_api_log(
+            $crate::__private_api::log(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!(), $crate::__private_api::line!()),
@@ -46,7 +46,7 @@ macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
-            $crate::__private_api_log(
+            $crate::__private_api::log(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!(), $crate::__private_api::line!()),
@@ -217,7 +217,7 @@ macro_rules! log_enabled {
         let lvl = $lvl;
         lvl <= $crate::STATIC_MAX_LEVEL
             && lvl <= $crate::max_level()
-            && $crate::__private_api_enabled(lvl, $target)
+            && $crate::__private_api::enabled(lvl, $target)
     }};
     ($lvl:expr) => {
         $crate::log_enabled!(target: $crate::__private_api::module_path!(), $lvl)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,7 +36,8 @@ macro_rules! log {
             $crate::__private_api::log(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
-                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!(), $crate::__private_api::line!()),
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
+                $crate::__private_api::line!(),
                 $crate::__private_api::Option::Some(&[$(($crate::__log_key!($key), &$value)),+])
             );
         }
@@ -49,7 +50,8 @@ macro_rules! log {
             $crate::__private_api::log(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
-                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!(), $crate::__private_api::line!()),
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
+                $crate::__private_api::line!(),
                 $crate::__private_api::Option::None,
             );
         }


### PR DESCRIPTION
This is the first step of bring optimizations from #569 into the `log` crate.

This PR contains two commits:

- The first commit moves all private APIs into a single `__private_api` module so that it is easier to implement more elaborated optimizations.
- The second commit splits `&(target, module_path, file, line)` argument into two arguments: `&(target, module_path, file)` and `line`. The idea is that a module could have more than one log calls, so most likely, these log calls would have the same `(target, module_path, file)` triple, group them together will allow multiple log calls to reuse a same `(target, module_path, file)` instance, see <https://godbolt.org/z/z7jW67Ece> for comparison.

For one of my internal projects, this PR will reduce the binary size by about 2%.

I also tested this PR on [`cargo-binstall`](https://crates.io/crates/cargo-binstall), this is the test result:

| opt-level | lto  | codegen-units | original size | optimized size | diff   |
| --------- | ---- | ------------- | ------------- | -------------- | ------ |
| 3         | off  |             1 |      14211752 |       14199464 | -12288 |
| 3         | off  |            16 |      16739048 |       16739048 |      0 |
| 3         | thin |             1 |      15170120 |       15166024 |  -4096 |
| 3         | thin |            16 |      17566376 |       17566376 |      0 |
| 3         | fat  |             1 |      13859336 |       13859336 |      0 |
| 3         | fat  |            16 |      15231496 |       15231496 |      0 |
| "z"       | off  |             1 |      11451048 |       11438760 | -12288 |
| "z"       | off  |            16 |      13531848 |       13511368 | -20480 |
| "z"       | thin |             1 |      12307048 |       12298856 |  -8192 |
| "z"       | thin |            16 |      13699720 |       13695624 |  -4096 |
| "z"       | fat  |             1 |       9951752 |        9935368 | -16384 |
| "z"       | fat  |            16 |      10476040 |       10459656 | -16384 |
