### PR TITLE
Specialize empty key value pairs

### DIFF
--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -1,55 +1,87 @@
 //! WARNING: this is not part of the crate's public API and is subject to change at any time
 
+use self::sealed::KVs;
 use crate::{Level, Metadata, Record};
 use std::fmt::Arguments;
-pub use std::option::Option;
 pub use std::{file, format_args, line, module_path, stringify};
 
+#[cfg(feature = "kv_unstable")]
+pub type Value<'a> = dyn crate::kv::value::ToValue + 'a;
+
 #[cfg(not(feature = "kv_unstable"))]
-pub fn log(
+pub type Value<'a> = str;
+
+mod sealed {
+    /// Types for the `kv` argument.
+    pub trait KVs<'a> {
+        fn into_kvs(self) -> Option<&'a [(&'a str, &'a super::Value<'a>)]>;
+    }
+}
+
+// Types for the `kv` argument.
+
+impl<'a> KVs<'a> for &'a [(&'a str, &'a Value<'a>)] {
+    #[inline]
+    fn into_kvs(self) -> Option<&'a [(&'a str, &'a Value<'a>)]> {
+        Some(self)
+    }
+}
+
+impl<'a> KVs<'a> for () {
+    #[inline]
+    fn into_kvs(self) -> Option<&'a [(&'a str, &'a Value<'a>)]> {
+        None
+    }
+}
+
+// Log implementation.
+
+fn log_impl(
     args: Arguments,
     level: Level,
     &(target, module_path, file): &(&str, &'static str, &'static str),
     line: u32,
-    kvs: Option<&[(&str, &str)]>,
+    kvs: Option<&[(&str, &Value)]>,
 ) {
+    #[cfg(not(feature = "kv_unstable"))]
     if kvs.is_some() {
         panic!(
             "key-value support is experimental and must be enabled using the `kv_unstable` feature"
         )
     }
 
-    crate::logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .build(),
-    );
+    let mut builder = Record::builder();
+
+    builder
+        .args(args)
+        .level(level)
+        .target(target)
+        .module_path_static(Some(module_path))
+        .file_static(Some(file))
+        .line(Some(line));
+
+    #[cfg(feature = "kv_unstable")]
+    builder.key_values(&kvs);
+
+    crate::logger().log(&builder.build());
 }
 
-#[cfg(feature = "kv_unstable")]
-pub fn log(
+pub fn log<'a, K>(
     args: Arguments,
     level: Level,
-    &(target, module_path, file): &(&str, &'static str, &'static str),
+    target_module_path_and_file: &(&str, &'static str, &'static str),
     line: u32,
-    kvs: Option<&[(&str, &dyn crate::kv::ToValue)]>,
-) {
-    crate::logger().log(
-        &Record::builder()
-            .args(args)
-            .level(level)
-            .target(target)
-            .module_path_static(Some(module_path))
-            .file_static(Some(file))
-            .line(Some(line))
-            .key_values(&kvs)
-            .build(),
-    );
+    kvs: K,
+) where
+    K: KVs<'a>,
+{
+    log_impl(
+        args,
+        level,
+        target_module_path_and_file,
+        line,
+        kvs.into_kvs(),
+    )
 }
 
 pub fn enabled(level: Level, target: &str) -> bool {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,12 +33,12 @@ macro_rules! log {
     (target: $target:expr, $lvl:expr, $($key:tt = $value:expr),+; $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
-            $crate::__private_api::log(
+            $crate::__private_api::log::<&_>(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
                 $crate::__private_api::line!(),
-                $crate::__private_api::Option::Some(&[$(($crate::__log_key!($key), &$value)),+])
+                &[$(($crate::__log_key!($key), &$value)),+]
             );
         }
     });
@@ -52,7 +52,7 @@ macro_rules! log {
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
                 $crate::__private_api::line!(),
-                $crate::__private_api::Option::None,
+                (),
             );
         }
     });


### PR DESCRIPTION
Currently, the `__private_api::log` function takes `None::<&[(&str, _)]>` as the `kvs` argument if no key-value pair is provided, but passing a `None` value may have some extra cost. We should be able to avoid this cost by encoding this information into a zero sized type (here I am using `()`, not sure if it is better to use a dedicated new type (such as `struct EmptyKVs;`)). Constructing a zero sized value is zero cost, which is less than constructing a `None::<&[(&str, _)]>`.