### PR TITLE
Update docs to 2021 edition, test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+* Migrate to 2021 edition and minor cleanups by @nyurik in https://github.com/rust-lang/log/pull/580
+* Use inline format args by @nyurik in https://github.com/rust-lang/log/pull/577
 
 ## [0.4.20] - 2023-07-11
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ pub fn shave_the_yak(yak: &mut Yak) {
     loop {
         match find_a_razor() {
             Ok(razor) => {
-                info!("Razor located: {}", razor);
+                info!("Razor located: {razor}");
                 yak.shave(razor);
                 break;
             }
             Err(err) => {
-                warn!("Unable to locate a razor: {}, retrying", err);
+                warn!("Unable to locate a razor: {err}, retrying");
             }
         }
     }

--- a/rfcs/0296-structured-logging.md
+++ b/rfcs/0296-structured-logging.md
@@ -337,7 +337,7 @@ fn log_record(w: impl Write, r: &Record) -> io::Result<()> {
     // Write each key-value pair on a new line
     record
         .key_values()
-        .for_each(|k, v| writeln!("{}: {}", k, v))?;
+        .for_each(|k, v| writeln!("{k}: {v}"))?;
 
     Ok(())
 }

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -967,7 +967,7 @@ pub(crate) mod tests {
 
         impl<'v> Visit<'v> for Extract {
             fn visit_any(&mut self, value: Value) -> Result<(), Error> {
-                unimplemented!("unexpected value: {:?}", value)
+                unimplemented!("unexpected value: {value:?}")
             }
 
             fn visit_u64(&mut self, value: u64) -> Result<(), Error> {
@@ -989,7 +989,7 @@ pub(crate) mod tests {
 
         impl<'v> Visit<'v> for Extract<'v> {
             fn visit_any(&mut self, value: Value) -> Result<(), Error> {
-                unimplemented!("unexpected value: {:?}", value)
+                unimplemented!("unexpected value: {value:?}")
             }
 
             fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,24 +48,24 @@
 //!
 //! ### Examples
 //!
-//! ```edition2018
+//! ```edition2021
 //! # #[derive(Debug)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
 //! # fn find_a_razor() -> Result<u32, u32> { Ok(1) }
 //! use log::{info, warn};
 //!
 //! pub fn shave_the_yak(yak: &mut Yak) {
-//!     info!(target: "yak_events", "Commencing yak shaving for {:?}", yak);
+//!     info!(target: "yak_events", "Commencing yak shaving for {yak:?}");
 //!
 //!     loop {
 //!         match find_a_razor() {
 //!             Ok(razor) => {
-//!                 info!("Razor located: {}", razor);
+//!                 info!("Razor located: {razor}");
 //!                 yak.shave(razor);
 //!                 break;
 //!             }
 //!             Err(err) => {
-//!                 warn!("Unable to locate a razor: {}, retrying", err);
+//!                 warn!("Unable to locate a razor: {err}, retrying");
 //!             }
 //!         }
 //!     }
@@ -92,7 +92,7 @@
 //! with your log records. If we take the example from before, we can include
 //! some additional context besides what's in the formatted message:
 //!
-//! ```edition2018
+//! ```edition2021
 //! # use serde::Serialize;
 //! # #[derive(Debug, Serialize)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
@@ -160,7 +160,7 @@
 //! logs all messages at the [`Error`][level_link], [`Warn`][level_link] or
 //! [`Info`][level_link] levels to stdout:
 //!
-//! ```edition2018
+//! ```edition2021
 //! use log::{Record, Level, Metadata};
 //!
 //! struct SimpleLogger;
@@ -193,7 +193,7 @@
 //! provide a function that wraps a call to [`set_logger`] and
 //! [`set_max_level`], handling initialization of the logger:
 //!
-//! ```edition2018
+//! ```edition2021
 //! # use log::{Level, Metadata};
 //! # struct SimpleLogger;
 //! # impl log::Log for SimpleLogger {
@@ -223,7 +223,7 @@
 //! identical to `set_logger` except that it takes a `Box<Log>` rather than a
 //! `&'static Log`:
 //!
-//! ```edition2018
+//! ```edition2021
 //! # use log::{Level, LevelFilter, Log, SetLoggerError, Metadata};
 //! # struct SimpleLogger;
 //! # impl log::Log for SimpleLogger {
@@ -688,7 +688,7 @@ impl<'a> MaybeStaticStr<'a> {
 /// The following example shows a simple logger that displays the level,
 /// module path, and message of any `Record` that is passed to it.
 ///
-/// ```edition2018
+/// ```edition2021
 /// struct SimpleLogger;
 ///
 /// impl log::Log for SimpleLogger {
@@ -845,7 +845,7 @@ impl<'a> Record<'a> {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::{Level, Record};
 ///
 /// let record = Record::builder()
@@ -860,7 +860,7 @@ impl<'a> Record<'a> {
 ///
 /// Alternatively, use [`MetadataBuilder`](struct.MetadataBuilder.html):
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::{Record, Level, MetadataBuilder};
 ///
 /// let error_metadata = MetadataBuilder::new()
@@ -1011,7 +1011,7 @@ impl<'a> Default for RecordBuilder<'a> {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::{Record, Level, Metadata};
 ///
 /// struct MyLogger;
@@ -1065,7 +1065,7 @@ impl<'a> Metadata<'a> {
 ///
 /// # Example
 ///
-/// ```edition2018
+/// ```edition2021
 /// let target = "myApp";
 /// use log::{Level, MetadataBuilder};
 /// let metadata = MetadataBuilder::new()
@@ -1315,7 +1315,7 @@ pub fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), SetLoggerError> {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::{error, info, warn, Record, Level, Metadata, LevelFilter};
 ///
 /// static MY_LOGGER: MyLogger = MyLogger;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! ### Examples
 //!
-//! ```edition2021
+//! ```
 //! # #[derive(Debug)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
 //! # fn find_a_razor() -> Result<u32, u32> { Ok(1) }
@@ -92,7 +92,7 @@
 //! with your log records. If we take the example from before, we can include
 //! some additional context besides what's in the formatted message:
 //!
-//! ```edition2021
+//! ```
 //! # use serde::Serialize;
 //! # #[derive(Debug, Serialize)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
@@ -160,7 +160,7 @@
 //! logs all messages at the [`Error`][level_link], [`Warn`][level_link] or
 //! [`Info`][level_link] levels to stdout:
 //!
-//! ```edition2021
+//! ```
 //! use log::{Record, Level, Metadata};
 //!
 //! struct SimpleLogger;
@@ -193,7 +193,7 @@
 //! provide a function that wraps a call to [`set_logger`] and
 //! [`set_max_level`], handling initialization of the logger:
 //!
-//! ```edition2021
+//! ```
 //! # use log::{Level, Metadata};
 //! # struct SimpleLogger;
 //! # impl log::Log for SimpleLogger {
@@ -223,7 +223,7 @@
 //! identical to `set_logger` except that it takes a `Box<Log>` rather than a
 //! `&'static Log`:
 //!
-//! ```edition2021
+//! ```
 //! # use log::{Level, LevelFilter, Log, SetLoggerError, Metadata};
 //! # struct SimpleLogger;
 //! # impl log::Log for SimpleLogger {
@@ -688,7 +688,7 @@ impl<'a> MaybeStaticStr<'a> {
 /// The following example shows a simple logger that displays the level,
 /// module path, and message of any `Record` that is passed to it.
 ///
-/// ```edition2021
+/// ```
 /// struct SimpleLogger;
 ///
 /// impl log::Log for SimpleLogger {
@@ -845,7 +845,7 @@ impl<'a> Record<'a> {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::{Level, Record};
 ///
 /// let record = Record::builder()
@@ -860,7 +860,7 @@ impl<'a> Record<'a> {
 ///
 /// Alternatively, use [`MetadataBuilder`](struct.MetadataBuilder.html):
 ///
-/// ```edition2021
+/// ```
 /// use log::{Record, Level, MetadataBuilder};
 ///
 /// let error_metadata = MetadataBuilder::new()
@@ -1011,7 +1011,7 @@ impl<'a> Default for RecordBuilder<'a> {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::{Record, Level, Metadata};
 ///
 /// struct MyLogger;
@@ -1065,7 +1065,7 @@ impl<'a> Metadata<'a> {
 ///
 /// # Example
 ///
-/// ```edition2021
+/// ```
 /// let target = "myApp";
 /// use log::{Level, MetadataBuilder};
 /// let metadata = MetadataBuilder::new()
@@ -1315,7 +1315,7 @@ pub fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), SetLoggerError> {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::{error, info, warn, Record, Level, Metadata, LevelFilter};
 ///
 /// static MY_LOGGER: MyLogger = MyLogger;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,7 @@
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::{log, Level};
 ///
 /// # fn main() {
@@ -65,14 +65,14 @@ macro_rules! log {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::error;
 ///
 /// # fn main() {
 /// let (err_info, port) = ("No connection", 22);
 ///
-/// error!("Error: {} on port {}", err_info, port);
-/// error!(target: "app_events", "App Error: {}, Port: {}", err_info, 22);
+/// error!("Error: {err_info} on port {port}");
+/// error!(target: "app_events", "App Error: {err_info}, Port: {port}");
 /// # }
 /// ```
 #[macro_export]
@@ -89,14 +89,14 @@ macro_rules! error {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::warn;
 ///
 /// # fn main() {
 /// let warn_description = "Invalid Input";
 ///
-/// warn!("Warning! {}!", warn_description);
-/// warn!(target: "input_events", "App received warning: {}", warn_description);
+/// warn!("Warning! {warn_description}!");
+/// warn!(target: "input_events", "App received warning: {warn_description}");
 /// # }
 /// ```
 #[macro_export]
@@ -113,7 +113,7 @@ macro_rules! warn {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::info;
 ///
 /// # fn main() {
@@ -139,7 +139,7 @@ macro_rules! info {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::debug;
 ///
 /// # fn main() {
@@ -164,7 +164,7 @@ macro_rules! debug {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::trace;
 ///
 /// # fn main() {
@@ -195,7 +195,7 @@ macro_rules! trace {
 ///
 /// # Examples
 ///
-/// ```edition2018
+/// ```edition2021
 /// use log::Level::Debug;
 /// use log::{debug, log_enabled};
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,7 @@
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::{log, Level};
 ///
 /// # fn main() {
@@ -65,7 +65,7 @@ macro_rules! log {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::error;
 ///
 /// # fn main() {
@@ -89,7 +89,7 @@ macro_rules! error {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::warn;
 ///
 /// # fn main() {
@@ -113,7 +113,7 @@ macro_rules! warn {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::info;
 ///
 /// # fn main() {
@@ -139,7 +139,7 @@ macro_rules! info {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::debug;
 ///
 /// # fn main() {
@@ -164,7 +164,7 @@ macro_rules! debug {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::trace;
 ///
 /// # fn main() {
@@ -195,7 +195,7 @@ macro_rules! trace {
 ///
 /// # Examples
 ///
-/// ```edition2021
+/// ```
 /// use log::Level::Debug;
 /// use log::{debug, log_enabled};
 ///

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -71,6 +71,28 @@ fn named_args() {
 }
 
 #[test]
+fn inlined_args() {
+    let world = "world";
+
+    for lvl in log::Level::iter() {
+        log!(lvl, "hello {world}");
+        log!(lvl, "hello {world}",);
+
+        log!(target: "my_target", lvl, "hello {world}");
+        log!(target: "my_target", lvl, "hello {world}",);
+
+        log!(lvl, "hello {world}");
+        log!(lvl, "hello {world}",);
+    }
+
+    all_log_macros!("hello {world}");
+    all_log_macros!("hello {world}",);
+
+    all_log_macros!(target: "my_target", "hello {world}");
+    all_log_macros!(target: "my_target", "hello {world}",);
+}
+
+#[test]
 fn enabled() {
     for lvl in log::Level::iter() {
         let _enabled = log_enabled!(target: "my_target", lvl);


### PR DESCRIPTION
* Inline format arg in documentation and a few call places
* Add a unit test for inlined format args

I was surprised to discover that log crate has no edition value... Any reason to keep it at 2015?