### PR TITLE
Minor clippy nits

### DIFF
--- a/benches/value.rs
+++ b/benches/value.rs
@@ -8,17 +8,17 @@ use log::kv::Value;
 
 #[bench]
 fn u8_to_value(b: &mut test::Bencher) {
-    b.iter(|| Value::from(1u8))
+    b.iter(|| Value::from(1u8));
 }
 
 #[bench]
 fn u8_to_value_debug(b: &mut test::Bencher) {
-    b.iter(|| Value::from_debug(&1u8))
+    b.iter(|| Value::from_debug(&1u8));
 }
 
 #[bench]
 fn str_to_value_debug(b: &mut test::Bencher) {
-    b.iter(|| Value::from_debug(&"a string"))
+    b.iter(|| Value::from_debug(&"a string"));
 }
 
 #[bench]
@@ -26,5 +26,5 @@ fn custom_to_value_debug(b: &mut test::Bencher) {
     #[derive(Debug)]
     struct A;
 
-    b.iter(|| Value::from_debug(&A))
+    b.iter(|| Value::from_debug(&A));
 }

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -187,7 +187,7 @@ where
     }
 
     fn count(&self) -> usize {
-        self.as_ref().map(Source::count).unwrap_or(0)
+        self.as_ref().map_or(0, Source::count)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1191,10 +1191,10 @@ where
     }
 
     fn log(&self, record: &Record) {
-        self.as_ref().log(record)
+        self.as_ref().log(record);
     }
     fn flush(&self) {
-        self.as_ref().flush()
+        self.as_ref().flush();
     }
 }
 
@@ -1208,10 +1208,10 @@ where
     }
 
     fn log(&self, record: &Record) {
-        self.as_ref().log(record)
+        self.as_ref().log(record);
     }
     fn flush(&self) {
-        self.as_ref().flush()
+        self.as_ref().flush();
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -213,7 +213,7 @@ mod tests {
     fn level_token(variant: &'static str) -> Token {
         Token::UnitVariant {
             name: "Level",
-            variant: variant,
+            variant,
         }
     }
 
@@ -236,7 +236,7 @@ mod tests {
     fn level_filter_token(variant: &'static str) -> Token {
         Token::UnitVariant {
             name: "LevelFilter",
-            variant: variant,
+            variant,
         }
     }
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -150,7 +150,7 @@ fn kv_named_args() {
 fn kv_expr_context() {
     match "chashu" {
         cat_1 => {
-            info!(target: "target", cat_1 = cat_1, cat_2 = "nori"; "hello {}", "cats")
+            info!(target: "target", cat_1 = cat_1, cat_2 = "nori"; "hello {}", "cats");
         }
     };
 }


### PR DESCRIPTION
* Fix semicolons (pedantic)
* Don't duplicate var name for instantiation if not needed
* Use `mar_or` instead of `map.unwrap_or`