### PR TITLE
Simplify Display impl

### DIFF
--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -47,10 +47,10 @@ impl fmt::Display for Error {
         use self::Inner::*;
         match &self.inner {
             #[cfg(feature = "std")]
-            &Boxed(ref err) => err.fmt(f),
-            &Value(ref err) => err.fmt(f),
-            &Msg(ref msg) => msg.fmt(f),
-            &Fmt => fmt::Error.fmt(f),
+            Boxed(err) => err.fmt(f),
+            Value(err) => err.fmt(f),
+            Msg(msg) => msg.fmt(f),
+            Fmt => fmt::Error.fmt(f),
         }
     }
 }


### PR DESCRIPTION
For some reason, `fmt::Display for Error` uses an unusual form `match &self.inner { &Value(ref err) => err.fmt(f), ...}`.  It seems `Value(err)` will work just as well.

If this is actually needed, we should add some comment explaining why so