### PR TITLE
Set all crates to 2021 edition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,11 @@ jobs:
         rustup update stable --no-self-update
         rustup default stable
         rustup component add rustfmt
+      # log repo does not use Cargo workspaces, so `cargo fmt` will not check all the code
+      # perhaps this should be changed in the future
     - run: cargo fmt -- --check
+    - run: cargo fmt --manifest-path test_max_level_features/Cargo.toml -- --check
+    - run: cargo fmt --manifest-path tests/Cargo.toml -- --check
 
   clippy:
     name: Clippy
@@ -74,6 +78,8 @@ jobs:
         rustup default stable
         rustup component add clippy
     - run: cargo clippy --verbose
+    - run: cargo clippy --verbose --manifest-path test_max_level_features/Cargo.toml
+    - run: cargo clippy --verbose --manifest-path tests/Cargo.toml
 
   doc:
     name: Check Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools::debugging"]
 keywords = ["logging"]
 exclude = ["rfcs/**/*"]
 rust-version = "1.60.0"
+edition = "2021"
 
 [package.metadata.docs.rs]
 features = ["std", "serde", "kv_unstable_std", "kv_unstable_sval", "kv_unstable_serde"]

--- a/benches/value.rs
+++ b/benches/value.rs
@@ -1,9 +1,6 @@
 #![cfg(feature = "kv_unstable")]
 #![feature(test)]
 
-extern crate log;
-extern crate test;
-
 use log::kv::Value;
 
 #[bench]

--- a/rfcs/0296-structured-logging.md
+++ b/rfcs/0296-structured-logging.md
@@ -1203,7 +1203,7 @@ Some useful adapters exist as provided methods on the `Source` trait. They're si
 
 - `by_ref` to get a reference to a `Source` within a method chain.
 - `chain` to concatenate one source with another. This is useful for composing implementations of `Log` together for contextual logging.
-- `get` to try find the value associated with a key. This is useful for well-defined key-value pairs that a framework built over `log` might want to provide, like timestamps or message templates.
+- `get` to try finding the value associated with a key. This is useful for well-defined key-value pairs that a framework built over `log` might want to provide, like timestamps or message templates.
 - `for_each` to execute some closure over all key-value pairs. This is a convenient way to do something with each key-value pair without having to create and implement a `Visitor`. One potential downside of `for_each` is the `Result` return value, which seems surprising when the closure itself can't fail. The `Source::for_each` call might itself fail if the underlying `visit` call fails when iterating over its key-value pairs. This shouldn't be common though, so when paired with `try_for_each`, it might be reasonable to make `for_each` return a `()` and rely on `try_for_each` for surfacing any fallibility.
 - `try_for_each` is like `for_each`, but takes a fallible closure.
 - `as_map` to get a serializable map. This is a convenient way to serialize key-value pairs without having to create and implement a `Visitor`.

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -103,11 +103,8 @@ mod std_support {
 mod sval_support {
     use super::*;
 
-    extern crate sval;
-    extern crate sval_ref;
-
-    use self::sval::Value;
-    use self::sval_ref::ValueRef;
+    use sval::Value;
+    use sval_ref::ValueRef;
 
     impl<'a> Value for Key<'a> {
         fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(
@@ -119,10 +116,7 @@ mod sval_support {
     }
 
     impl<'a> ValueRef<'a> for Key<'a> {
-        fn stream_ref<S: self::sval::Stream<'a> + ?Sized>(
-            &self,
-            stream: &mut S,
-        ) -> self::sval::Result {
+        fn stream_ref<S: sval::Stream<'a> + ?Sized>(&self, stream: &mut S) -> sval::Result {
             self.key.stream(stream)
         }
     }
@@ -132,9 +126,7 @@ mod sval_support {
 mod serde_support {
     use super::*;
 
-    extern crate serde;
-
-    use self::serde::{Serialize, Serializer};
+    use serde::{Serialize, Serializer};
 
     impl<'a> Serialize for Key<'a> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -2,19 +2,9 @@
 
 use std::fmt;
 
-extern crate value_bag;
+pub use crate::kv::Error;
 
-#[cfg(feature = "kv_unstable_sval")]
-extern crate sval;
-#[cfg(feature = "kv_unstable_sval")]
-extern crate sval_ref;
-
-#[cfg(feature = "kv_unstable_serde")]
-extern crate serde;
-
-use self::value_bag::ValueBag;
-
-pub use kv::Error;
+use value_bag::ValueBag;
 
 /// A type that can be converted into a [`Value`](struct.Value.html).
 pub trait ToValue {
@@ -199,7 +189,7 @@ impl<'v> Value<'v> {
     /// Get a value from a type implementing `serde::Serialize`.
     pub fn capture_serde<T>(value: &'v T) -> Self
     where
-        T: self::serde::Serialize + 'static,
+        T: serde::Serialize + 'static,
     {
         Value {
             inner: ValueBag::capture_serde1(value),
@@ -210,7 +200,7 @@ impl<'v> Value<'v> {
     #[cfg(feature = "kv_unstable_sval")]
     pub fn capture_sval<T>(value: &'v T) -> Self
     where
-        T: self::sval::Value + 'static,
+        T: sval::Value + 'static,
     {
         Value {
             inner: ValueBag::capture_sval2(value),
@@ -241,7 +231,7 @@ impl<'v> Value<'v> {
     #[cfg(feature = "kv_unstable_serde")]
     pub fn from_serde<T>(value: &'v T) -> Self
     where
-        T: self::serde::Serialize,
+        T: serde::Serialize,
     {
         Value {
             inner: ValueBag::from_serde1(value),
@@ -252,7 +242,7 @@ impl<'v> Value<'v> {
     #[cfg(feature = "kv_unstable_sval")]
     pub fn from_sval<T>(value: &'v T) -> Self
     where
-        T: self::sval::Value,
+        T: sval::Value,
     {
         Value {
             inner: ValueBag::from_sval2(value),
@@ -406,29 +396,26 @@ impl ToValue for dyn std::error::Error + 'static {
 }
 
 #[cfg(feature = "kv_unstable_serde")]
-impl<'v> self::serde::Serialize for Value<'v> {
+impl<'v> serde::Serialize for Value<'v> {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S: self::serde::Serializer,
+        S: serde::Serializer,
     {
         self.inner.serialize(s)
     }
 }
 
 #[cfg(feature = "kv_unstable_sval")]
-impl<'v> self::sval::Value for Value<'v> {
-    fn stream<'sval, S: self::sval::Stream<'sval> + ?Sized>(
-        &'sval self,
-        stream: &mut S,
-    ) -> self::sval::Result {
-        self::sval::Value::stream(&self.inner, stream)
+impl<'v> sval::Value for Value<'v> {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        sval::Value::stream(&self.inner, stream)
     }
 }
 
 #[cfg(feature = "kv_unstable_sval")]
-impl<'v> self::sval_ref::ValueRef<'v> for Value<'v> {
-    fn stream_ref<S: self::sval::Stream<'v> + ?Sized>(&self, stream: &mut S) -> self::sval::Result {
-        self::sval_ref::ValueRef::stream_ref(&self.inner, stream)
+impl<'v> sval_ref::ValueRef<'v> for Value<'v> {
+    fn stream_ref<S: sval::Stream<'v> + ?Sized>(&self, stream: &mut S) -> sval::Result {
+        sval_ref::ValueRef::stream_ref(&self.inner, stream)
     }
 }
 
@@ -601,9 +588,9 @@ impl<'v> Value<'v> {
 
 #[cfg(feature = "kv_unstable_std")]
 mod std_support {
-    use super::*;
-
     use std::borrow::Cow;
+
+    use super::*;
 
     impl<T> ToValue for Box<T>
     where
@@ -773,8 +760,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-
-    pub(crate) use super::value_bag::test::TestToken as Token;
+    pub(crate) use value_bag::test::TestToken as Token;
 
     impl<'v> Value<'v> {
         pub(crate) fn to_token(&self) -> Token {
@@ -874,7 +860,7 @@ pub(crate) mod tests {
         assert_eq!("a loong string".to_value().to_string(), "a loong string");
         assert_eq!(Some(true).to_value().to_string(), "true");
         assert_eq!(().to_value().to_string(), "None");
-        assert_eq!(Option::None::<bool>.to_value().to_string(), "None");
+        assert_eq!(None::<bool>.to_value().to_string(), "None");
     }
 
     #[test]
@@ -890,7 +876,7 @@ pub(crate) mod tests {
         );
         assert_eq!(Some(true).to_value().to_token(), Token::Bool(true));
         assert_eq!(().to_value().to_token(), Token::None);
-        assert_eq!(Option::None::<bool>.to_value().to_token(), Token::None);
+        assert_eq!(None::<bool>.to_value().to_token(), Token::None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! some additional context besides what's in the formatted message:
 //!
 //! ```edition2018
-//! # #[macro_use] extern crate serde;
+//! # use serde::Serialize;
 //! # #[derive(Debug, Serialize)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
 //! # fn find_a_razor() -> Result<u32, std::io::Error> { Ok(1) }
@@ -334,12 +334,10 @@
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
-use std::cmp;
 #[cfg(feature = "std")]
 use std::error;
-use std::fmt;
-use std::mem;
 use std::str::FromStr;
+use std::{cmp, fmt, mem};
 
 #[macro_use]
 mod macros;
@@ -906,7 +904,7 @@ impl<'a> RecordBuilder<'a> {
                 file: None,
                 line: None,
                 #[cfg(feature = "kv_unstable")]
-                key_values: KeyValues(&Option::None::<(kv::Key, kv::Value)>),
+                key_values: KeyValues(&None::<(kv::Key, kv::Value)>),
             },
         }
     }
@@ -1537,9 +1535,7 @@ const fn get_max_level_inner() -> LevelFilter {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
     use super::{Level, LevelFilter, ParseLevelError};
-    use tests::std::string::ToString;
 
     #[test]
     fn test_levelfilter_from_str() {
@@ -1748,7 +1744,7 @@ mod tests {
     #[cfg(feature = "kv_unstable")]
     fn test_record_key_values_builder() {
         use super::Record;
-        use kv::{self, Visitor};
+        use crate::kv::{self, Visitor};
 
         struct TestVisitor {
             seen_pairs: usize,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,13 +1,12 @@
 #![cfg(feature = "serde")]
 
-extern crate serde;
-use self::serde::de::{
+use serde::de::{
     Deserialize, DeserializeSeed, Deserializer, EnumAccess, Error, Unexpected, VariantAccess,
     Visitor,
 };
-use self::serde::ser::{Serialize, Serializer};
+use serde::ser::{Serialize, Serializer};
 
-use {Level, LevelFilter, LOG_LEVEL_NAMES};
+use crate::{Level, LevelFilter, LOG_LEVEL_NAMES};
 
 use std::fmt;
 use std::str::{self, FromStr};
@@ -43,6 +42,17 @@ impl<'de> Deserialize<'de> for Level {
                 formatter.write_str("log level")
             }
 
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let variant = LOG_LEVEL_NAMES[1..]
+                    .get(v as usize)
+                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
+
+                self.visit_str(variant)
+            }
+
             fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
             where
                 E: Error,
@@ -57,17 +67,6 @@ impl<'de> Deserialize<'de> for Level {
             {
                 let variant = str::from_utf8(value)
                     .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
-
-                self.visit_str(variant)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                let variant = LOG_LEVEL_NAMES[1..]
-                    .get(v as usize)
-                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
 
                 self.visit_str(variant)
             }
@@ -138,6 +137,17 @@ impl<'de> Deserialize<'de> for LevelFilter {
                 formatter.write_str("log level filter")
             }
 
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let variant = LOG_LEVEL_NAMES
+                    .get(v as usize)
+                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
+
+                self.visit_str(variant)
+            }
+
             fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
             where
                 E: Error,
@@ -152,17 +162,6 @@ impl<'de> Deserialize<'de> for LevelFilter {
             {
                 let variant = str::from_utf8(value)
                     .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
-
-                self.visit_str(variant)
-            }
-
-            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                let variant = LOG_LEVEL_NAMES
-                    .get(v as usize)
-                    .ok_or_else(|| Error::invalid_value(Unexpected::Unsigned(v), &self))?;
 
                 self.visit_str(variant)
             }
@@ -205,10 +204,8 @@ impl<'de> Deserialize<'de> for LevelFilter {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_test;
-    use self::serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
-
-    use {Level, LevelFilter};
+    use crate::{Level, LevelFilter};
+    use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
 
     fn level_token(variant: &'static str) -> Token {
         Token::UnitVariant {
@@ -262,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_level_ser_de() {
-        let cases = [
+        let cases = &[
             (Level::Error, [level_token("ERROR")]),
             (Level::Warn, [level_token("WARN")]),
             (Level::Info, [level_token("INFO")]),
@@ -270,14 +267,14 @@ mod tests {
             (Level::Trace, [level_token("TRACE")]),
         ];
 
-        for &(s, expected) in &cases {
-            assert_tokens(&s, &expected);
+        for (s, expected) in cases {
+            assert_tokens(s, expected);
         }
     }
 
     #[test]
     fn test_level_case_insensitive() {
-        let cases = [
+        let cases = &[
             (Level::Error, [level_token("error")]),
             (Level::Warn, [level_token("warn")]),
             (Level::Info, [level_token("info")]),
@@ -285,14 +282,14 @@ mod tests {
             (Level::Trace, [level_token("trace")]),
         ];
 
-        for &(s, expected) in &cases {
-            assert_de_tokens(&s, &expected);
+        for (s, expected) in cases {
+            assert_de_tokens(s, expected);
         }
     }
 
     #[test]
     fn test_level_de_bytes() {
-        let cases = [
+        let cases = &[
             (Level::Error, level_bytes_tokens(b"ERROR")),
             (Level::Warn, level_bytes_tokens(b"WARN")),
             (Level::Info, level_bytes_tokens(b"INFO")),
@@ -300,14 +297,14 @@ mod tests {
             (Level::Trace, level_bytes_tokens(b"TRACE")),
         ];
 
-        for &(value, tokens) in &cases {
-            assert_de_tokens(&value, &tokens);
+        for (value, tokens) in cases {
+            assert_de_tokens(value, tokens);
         }
     }
 
     #[test]
     fn test_level_de_variant_index() {
-        let cases = [
+        let cases = &[
             (Level::Error, level_variant_tokens(0)),
             (Level::Warn, level_variant_tokens(1)),
             (Level::Info, level_variant_tokens(2)),
@@ -315,8 +312,8 @@ mod tests {
             (Level::Trace, level_variant_tokens(4)),
         ];
 
-        for &(value, tokens) in &cases {
-            assert_de_tokens(&value, &tokens);
+        for (value, tokens) in cases {
+            assert_de_tokens(value, tokens);
         }
     }
 
@@ -329,7 +326,7 @@ mod tests {
 
     #[test]
     fn test_level_filter_ser_de() {
-        let cases = [
+        let cases = &[
             (LevelFilter::Off, [level_filter_token("OFF")]),
             (LevelFilter::Error, [level_filter_token("ERROR")]),
             (LevelFilter::Warn, [level_filter_token("WARN")]),
@@ -338,14 +335,14 @@ mod tests {
             (LevelFilter::Trace, [level_filter_token("TRACE")]),
         ];
 
-        for &(s, expected) in &cases {
-            assert_tokens(&s, &expected);
+        for (s, expected) in cases {
+            assert_tokens(s, expected);
         }
     }
 
     #[test]
     fn test_level_filter_case_insensitive() {
-        let cases = [
+        let cases = &[
             (LevelFilter::Off, [level_filter_token("off")]),
             (LevelFilter::Error, [level_filter_token("error")]),
             (LevelFilter::Warn, [level_filter_token("warn")]),
@@ -354,14 +351,14 @@ mod tests {
             (LevelFilter::Trace, [level_filter_token("trace")]),
         ];
 
-        for &(s, expected) in &cases {
-            assert_de_tokens(&s, &expected);
+        for (s, expected) in cases {
+            assert_de_tokens(s, expected);
         }
     }
 
     #[test]
     fn test_level_filter_de_bytes() {
-        let cases = [
+        let cases = &[
             (LevelFilter::Off, level_filter_bytes_tokens(b"OFF")),
             (LevelFilter::Error, level_filter_bytes_tokens(b"ERROR")),
             (LevelFilter::Warn, level_filter_bytes_tokens(b"WARN")),
@@ -370,14 +367,14 @@ mod tests {
             (LevelFilter::Trace, level_filter_bytes_tokens(b"TRACE")),
         ];
 
-        for &(value, tokens) in &cases {
-            assert_de_tokens(&value, &tokens);
+        for (value, tokens) in cases {
+            assert_de_tokens(value, tokens);
         }
     }
 
     #[test]
     fn test_level_filter_de_variant_index() {
-        let cases = [
+        let cases = &[
             (LevelFilter::Off, level_filter_variant_tokens(0)),
             (LevelFilter::Error, level_filter_variant_tokens(1)),
             (LevelFilter::Warn, level_filter_variant_tokens(2)),
@@ -386,8 +383,8 @@ mod tests {
             (LevelFilter::Trace, level_filter_variant_tokens(5)),
         ];
 
-        for &(value, tokens) in &cases {
-            assert_de_tokens(&value, &tokens);
+        for (value, tokens) in cases {
+            assert_de_tokens(value, tokens);
         }
     }
 

--- a/test_max_level_features/Cargo.toml
+++ b/test_max_level_features/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "optimized"
 version = "0.1.0"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/test_max_level_features/main.rs
+++ b/test_max_level_features/main.rs
@@ -1,13 +1,10 @@
-#[macro_use]
-extern crate log;
-
+use log::{debug, error, info, trace, warn, Level, LevelFilter, Log, Metadata, Record};
 use std::sync::{Arc, Mutex};
-use log::{Level, LevelFilter, Log, Record, Metadata};
 
 #[cfg(feature = "std")]
 use log::set_boxed_logger;
 #[cfg(not(feature = "std"))]
-fn set_boxed_logger(logger: Box<Log>) -> Result<(), log::SetLoggerError> {
+fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
     log::set_logger(Box::leak(logger))
 }
 
@@ -30,7 +27,9 @@ impl Log for Logger {
 }
 
 fn main() {
-    let me = Arc::new(State { last_log: Mutex::new(None) });
+    let me = Arc::new(State {
+        last_log: Mutex::new(None),
+    });
     let a = me.clone();
     set_boxed_logger(Box::new(Logger(me))).unwrap();
 
@@ -62,7 +61,11 @@ fn test(a: &State, filter: LevelFilter) {
     last(&a, None);
 
     fn t(lvl: Level, filter: LevelFilter) -> Option<Level> {
-        if lvl <= filter {Some(lvl)} else {None}
+        if lvl <= filter {
+            Some(lvl)
+        } else {
+            None
+        }
     }
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "integration"
 version = "0.1.0"
+edition = "2021"
 publish = false
 build = "src/build.rs"
 

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,10 +1,6 @@
 #![allow(dead_code, unused_imports)]
 
-#[cfg(not(lib_build))]
-#[macro_use]
-extern crate log;
-
-use log::{Level, LevelFilter, Log, Metadata, Record};
+use log::{debug, error, info, trace, warn, Level, LevelFilter, Log, Metadata, Record};
 use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "std")]

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,14 +1,12 @@
-#[cfg(not(lib_build))]
-#[macro_use]
-extern crate log;
+use log::{log, log_enabled};
 
 macro_rules! all_log_macros {
     ($($arg:tt)*) => ({
-        trace!($($arg)*);
-        debug!($($arg)*);
-        info!($($arg)*);
-        warn!($($arg)*);
-        error!($($arg)*);
+        ::log::trace!($($arg)*);
+        ::log::debug!($($arg)*);
+        ::log::info!($($arg)*);
+        ::log::warn!($($arg)*);
+        ::log::error!($($arg)*);
     });
 }
 
@@ -150,7 +148,7 @@ fn kv_named_args() {
 fn kv_expr_context() {
     match "chashu" {
         cat_1 => {
-            info!(target: "target", cat_1 = cat_1, cat_2 = "nori"; "hello {}", "cats");
+            log::info!(target: "target", cat_1 = cat_1, cat_2 = "nori"; "hello {}", "cats");
         }
     };
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,13 +1,9 @@
 //! This crate is intentionally left empty.
-//! 
+//!
 //! We have an empty library depending on `log` here so we can run integration tests
 //! on older compilers without depending on the unstable `no-dev-deps` flag.
 
 #![allow(dead_code)]
-
-#[cfg(test)]
-#[macro_use]
-extern crate log;
 
 #[cfg(test)]
 #[path = "../filters.rs"]


### PR DESCRIPTION
For some reason all crates still use 2015 edition. I think it is a good idea to specify edition explicitly, or at least document why it should be kept back (and still add it to the cargo.toml for documentation purposes)

* Remove all `extern crate`
* changed `use self::sval::...` to `use sval::...`, and the same for `sval_ref`
* Simplified `fn get<'v>(&'v self, key: Key) -> Option<Value<'v>>` to `fn get(&self, key: Key) -> Option<Value<'_>>`
* Simplified many unit tests with references