### PR TITLE
Add column numbers

### DIFF
--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -3,7 +3,7 @@
 use crate::{Level, Metadata, Record};
 use std::fmt::Arguments;
 pub use std::option::Option;
-pub use std::{file, format_args, line, module_path, stringify};
+pub use std::{column, file, format_args, line, module_path, stringify};
 
 #[cfg(not(feature = "kv_unstable"))]
 pub fn log(
@@ -11,6 +11,7 @@ pub fn log(
     level: Level,
     &(target, module_path, file): &(&str, &'static str, &'static str),
     line: u32,
+    column: u32,
     kvs: Option<&[(&str, &str)]>,
 ) {
     if kvs.is_some() {
@@ -27,6 +28,7 @@ pub fn log(
             .module_path_static(Some(module_path))
             .file_static(Some(file))
             .line(Some(line))
+            .column(Some(column))
             .build(),
     );
 }
@@ -37,6 +39,7 @@ pub fn log(
     level: Level,
     &(target, module_path, file): &(&str, &'static str, &'static str),
     line: u32,
+    column: u32,
     kvs: Option<&[(&str, &dyn crate::kv::ToValue)]>,
 ) {
     crate::logger().log(
@@ -47,6 +50,7 @@ pub fn log(
             .module_path_static(Some(module_path))
             .file_static(Some(file))
             .line(Some(line))
+            .column(Some(column))
             .key_values(&kvs)
             .build(),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,6 +724,7 @@ pub struct Record<'a> {
     module_path: Option<MaybeStaticStr<'a>>,
     file: Option<MaybeStaticStr<'a>>,
     line: Option<u32>,
+    column: Option<u32>,
     #[cfg(feature = "kv_unstable")]
     key_values: KeyValues<'a>,
 }
@@ -812,6 +813,12 @@ impl<'a> Record<'a> {
         self.line
     }
 
+    /// The column containing the message.
+    #[inline]
+    pub fn column(&self) -> Option<u32> {
+        self.column
+    }
+
     /// The structured key-value pairs associated with the message.
     #[cfg(feature = "kv_unstable")]
     #[inline]
@@ -833,6 +840,7 @@ impl<'a> Record<'a> {
                 module_path: self.module_path,
                 file: self.file,
                 line: self.line,
+                column: self.column,
                 key_values: self.key_values.clone(),
             },
         }
@@ -856,6 +864,7 @@ impl<'a> Record<'a> {
 ///                 .target("myApp")
 ///                 .file(Some("server.rs"))
 ///                 .line(Some(144))
+///                 .column(Some(12))
 ///                 .module_path(Some("server"))
 ///                 .build();
 /// ```
@@ -874,6 +883,7 @@ impl<'a> Record<'a> {
 ///                 .metadata(error_metadata)
 ///                 .args(format_args!("Error!"))
 ///                 .line(Some(433))
+///                 .column(Some(22))
 ///                 .file(Some("app.rs"))
 ///                 .module_path(Some("server"))
 ///                 .build();
@@ -893,6 +903,7 @@ impl<'a> RecordBuilder<'a> {
     /// - `module_path`: `None`
     /// - `file`: `None`
     /// - `line`: `None`
+    /// - `column`: `None`
     ///
     /// [`format_args!("")`]: https://doc.rust-lang.org/std/macro.format_args.html
     /// [`Metadata::builder().build()`]: struct.MetadataBuilder.html#method.build
@@ -905,6 +916,7 @@ impl<'a> RecordBuilder<'a> {
                 module_path: None,
                 file: None,
                 line: None,
+                column: None,
                 #[cfg(feature = "kv_unstable")]
                 key_values: KeyValues(&Option::None::<(kv::Key, kv::Value)>),
             },
@@ -971,6 +983,13 @@ impl<'a> RecordBuilder<'a> {
     #[inline]
     pub fn line(&mut self, line: Option<u32>) -> &mut RecordBuilder<'a> {
         self.record.line = line;
+        self
+    }
+
+    /// Set [`column`](struct.Record.html#method.column)
+    #[inline]
+    pub fn column(&mut self, column: Option<u32>) -> &mut RecordBuilder<'a> {
+        self.record.column = column;
         self
     }
 
@@ -1700,11 +1719,13 @@ mod tests {
             .module_path(Some("foo"))
             .file(Some("bar"))
             .line(Some(30))
+            .column(Some(12))
             .build();
         assert_eq!(record_test.metadata().target(), "myApp");
         assert_eq!(record_test.module_path(), Some("foo"));
         assert_eq!(record_test.file(), Some("bar"));
         assert_eq!(record_test.line(), Some(30));
+        assert_eq!(record_test.column(), Some(12));
     }
 
     #[test]
@@ -1719,11 +1740,13 @@ mod tests {
             .module_path(Some("foo"))
             .file(Some("bar"))
             .line(Some(30))
+            .column(Some(12))
             .build();
         assert_eq!(record_test.target(), "myApp");
         assert_eq!(record_test.module_path(), Some("foo"));
         assert_eq!(record_test.file(), Some("bar"));
         assert_eq!(record_test.line(), Some(30));
+        assert_eq!(record_test.column(), Some(12));
     }
 
     #[test]
@@ -1734,6 +1757,7 @@ mod tests {
             .module_path(Some("foo"))
             .file(Some("bar"))
             .line(Some(30))
+            .column(Some(12))
             .target(target)
             .level(Level::Error)
             .build();
@@ -1742,6 +1766,7 @@ mod tests {
         assert_eq!(record_test.module_path(), Some("foo"));
         assert_eq!(record_test.file(), Some("bar"));
         assert_eq!(record_test.line(), Some(30));
+        assert_eq!(record_test.column(), Some(12));
     }
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,6 +38,7 @@ macro_rules! log {
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
                 $crate::__private_api::line!(),
+                $crate::__private_api::column!(),
                 $crate::__private_api::Option::Some(&[$(($crate::__log_key!($key), &$value)),+])
             );
         }
@@ -52,6 +53,7 @@ macro_rules! log {
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
                 $crate::__private_api::line!(),
+                $crate::__private_api::column!(),
                 $crate::__private_api::Option::None,
             );
         }


### PR DESCRIPTION
This adds column numbers to logs, using the [`column!`](https://doc.rust-lang.org/stable/std/macro.column.html) macro.