### PR TITLE
migrate to a single workspace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,8 @@ jobs:
     - run: cargo test --verbose --features kv_unstable_sval
     - run: cargo test --verbose --features kv_unstable_serde
     - run: cargo test --verbose --features "kv_unstable kv_unstable_std kv_unstable_sval kv_unstable_serde"
-    - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
-    - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
+    - run: cargo run --verbose -p test_max_level_features
+    - run: cargo run --verbose -p test_max_level_features --release
 
   rustfmt:
     name: Rustfmt
@@ -61,10 +61,7 @@ jobs:
         rustup update stable --no-self-update
         rustup default stable
         rustup component add rustfmt
-      # log repo does not use Cargo workspaces, so `cargo fmt` will not check all the code
-      # perhaps this should be changed in the future
     - run: cargo fmt -- --check
-    - run: cargo fmt --manifest-path test_max_level_features/Cargo.toml -- --check
     - run: cargo fmt --manifest-path tests/Cargo.toml -- --check
 
   clippy:
@@ -78,7 +75,6 @@ jobs:
         rustup default stable
         rustup component add clippy
     - run: cargo clippy --verbose
-    - run: cargo clippy --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo clippy --verbose --manifest-path tests/Cargo.toml
 
   doc:
@@ -135,6 +131,7 @@ jobs:
         run: |
           rustup update 1.60.0 --no-self-update
           rustup default 1.60.0
+      - run: cargo test --verbose
       - run: cargo test --verbose --manifest-path tests/Cargo.toml
 
   embedded:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "log"
 version = "0.4.20" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
@@ -73,3 +72,10 @@ value-bag = { version = "1.4", features = ["test"] }
 # By defining the crate as direct dependency we can increase it's minimal
 # version making the minimal (crate) version CI happy.
 proc-macro2 = { version = "1.0.63", default-features = false }
+
+[workspace]
+# TODO: the tests/ dir for historic reasons has a hacky setup as both tests/ dir and as tests crate.
+#       It breaks if it is added here, so this should be done at some later time
+members = [".", "test_max_level_features"]
+# The test_max_level_features test crate would not compile by default for no_std targets
+default-members = ["."]

--- a/test_max_level_features/Cargo.toml
+++ b/test_max_level_features/Cargo.toml
@@ -1,13 +1,8 @@
 [package]
-name = "optimized"
+name = "test_max_level_features"
 version = "0.1.0"
 edition = "2021"
 publish = false
 
-[[bin]]
-name = "test_max_level_features"
-path = "main.rs"
-
-[dependencies.log]
-path = ".."
-features = ["max_level_debug", "release_max_level_info"]
+[dependencies]
+log = { path = "..", features = ["max_level_debug", "release_max_level_info"] }

--- a/test_max_level_features/src/main.rs
+++ b/test_max_level_features/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "std")]
 use log::set_boxed_logger;
+
 #[cfg(not(feature = "std"))]
 fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
     log::set_logger(Box::leak(logger))
@@ -44,21 +45,21 @@ fn main() {
 fn test(a: &State, filter: LevelFilter) {
     log::set_max_level(filter);
     error!("");
-    last(&a, t(Level::Error, filter));
+    last(a, t(Level::Error, filter));
     warn!("");
-    last(&a, t(Level::Warn, filter));
+    last(a, t(Level::Warn, filter));
     info!("");
-    last(&a, t(Level::Info, filter));
+    last(a, t(Level::Info, filter));
 
     debug!("");
     if cfg!(debug_assertions) {
-        last(&a, t(Level::Debug, filter));
+        last(a, t(Level::Debug, filter));
     } else {
-        last(&a, None);
+        last(a, None);
     }
 
     trace!("");
-    last(&a, None);
+    last(a, None);
 
     fn t(lvl: Level, filter: LevelFilter) -> Option<Level> {
         if lvl <= filter {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,3 +1,6 @@
+# This is a hack, see comment in the root Cargo.toml
+[workspace]
+
 [package]
 name = "integration"
 version = "0.1.0"
@@ -8,8 +11,8 @@ build = "src/build.rs"
 [features]
 std = ["log/std"]
 
-[dependencies.log]
-path = ".."
+[dependencies]
+log = { path = ".." }
 
-[dev-dependencies.rustversion]
-version = "1.0"
+[dev-dependencies]
+rustversion = "1.0"


### PR DESCRIPTION
Consolidate the build setup for all crates to use 2021-style cargo.toml with workspaces.  Note that the `tests/` dir has an unusual setup, where the tests dir is both a separate crate and a set of integration tests for the log crate.

I am not certain of all the interactions here, and making it into a regular test crate breaks the filter test, so leaving as is for now until someone can explain what's going on there.