### PR TITLE
Fix incorrect lifetime in Value::to_str()

### DIFF
--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -635,7 +635,7 @@ mod std_support {
 
     impl<'v> Value<'v> {
         /// Try convert this value into a string.
-        pub fn to_str(&self) -> Option<Cow<str>> {
+        pub fn to_str(&self) -> Option<Cow<'v, str>> {
             self.inner.to_str()
         }
     }


### PR DESCRIPTION
Without this change, the following code will not compile:

```Rust
let foo = record
    .key_values()
    .get(Key::from_str("foo"))
    .and_then(|val| val.to_str());
```
with the following error:

```lang-none
   |
32 |         .and_then(|val| val.to_str());
   |                         ^^^^^^^^^^^^ returns a reference to data owned by the current function
```