### PR TITLE
Add "alterable_logger" link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ There are many available implementations to choose from, here are some options:
 * Utilities:
     * [`log_err`](https://docs.rs/log_err/*/log_err/)
     * [`log-reload`](https://docs.rs/log-reload/*/log_reload/)
+    * [`alterable_logger`](https://docs.rs/alterable_logger/*/alterable_logger)
 
 Executables should choose a logger implementation and initialize it early in the
 runtime of the program. Logger implementations will typically include a


### PR DESCRIPTION
Hi, 

I wrote a utility crate for log. To promote it, I though it is a good Idea to add a link to the log README file. Here is the corresponding PR.

Cheers Simon