### PR TITLE
Add logcontrol-log and log-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ There are many available implementations to choose from, here are some options:
     * [`win_dbg_logger`](https://docs.rs/win_dbg_logger/*/win_dbg_logger/)
     * [`db_logger`](https://docs.rs/db_logger/*/db_logger/)
     * [`log-to-defmt`](https://docs.rs/log-to-defmt/*/log_to_defmt/)
+    * [`logcontrol-log`](https://docs.rs/logcontrol-log/*/logcontrol_log/)
 * For WebAssembly binaries:
     * [`console_log`](https://docs.rs/console_log/*/console_log/)
 * For dynamic libraries:
     * You may need to construct [an FFI-safe wrapper over `log`](https://github.com/rust-lang/log/issues/421) to initialize in your libraries.
 * Utilities:
     * [`log_err`](https://docs.rs/log_err/*/log_err/)
+    * [`log-reload`](https://docs.rs/log-reload/*/log_reload/)
 
 Executables should choose a logger implementation and initialize it early in the
 runtime of the program. Logger implementations will typically include a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,10 +149,14 @@
 //!     * [win_dbg_logger]
 //!     * [db_logger]
 //!     * [log-to-defmt]
+//!     * [logcontrol-log]
 //! * For WebAssembly binaries:
 //!     * [console_log]
 //! * For dynamic libraries:
 //!     * You may need to construct an FFI-safe wrapper over `log` to initialize in your libraries
+//! * Utilities:
+//!     * [log_err]
+//!     * [log-reload]
 //!
 //! # Implementing a Logger
 //!
@@ -317,6 +321,9 @@
 //! [log-to-defmt]: https://docs.rs/log-to-defmt/*/log_to_defmt/
 //! [console_log]: https://docs.rs/console_log/*/console_log/
 //! [structured-logger]: https://docs.rs/structured-logger/latest/structured_logger/
+//! [logcontrol-log]: https://docs.rs/logcontrol-log/*/logcontrol_log/
+//! [log_err]: https://docs.rs/log_err/*/log_err/
+//! [log-reload]: https://docs.rs/log-reload/*/log_reload/
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",


### PR DESCRIPTION
logcontrol-log provides a log adaptor for the systemd logcontrol interface which enables on-the-fly reconfiguration of logging over DBus.

log-reload is a utility crate providing a log implementation that can dynamically modify and replace an underlying logger.  It backs the logcontrol-log implementation.

Disclaimer: These are my crates, but I find them very useful in system services, so I hope this doesn't qualify as self promotion.