### PR TITLE
Specialize target and level arguments that can be statically determined

### DIFF
--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -1,7 +1,8 @@
 //! WARNING: this is not part of the crate's public API and is subject to change at any time
 
-use self::sealed::KVs;
-use crate::{Level, Metadata, Record};
+use self::sealed::{KVs, Level as LevelTrait, Target};
+use crate::{Level, LevelFilter, Metadata, Record};
+use std::cmp::Ordering;
 use std::fmt::Arguments;
 pub use std::{file, format_args, line, module_path, stringify};
 
@@ -12,14 +13,43 @@ pub type Value<'a> = dyn crate::kv::value::ToValue + 'a;
 pub type Value<'a> = str;
 
 mod sealed {
+    /// Types for the `target` argument.
+    pub trait Target<'a>: Copy {
+        fn into_target(self, module_path: &'a str) -> &'a str;
+    }
+
+    /// Types for the `level` argument.
+    pub trait Level: Copy {
+        fn into_level(self) -> crate::Level;
+    }
+
     /// Types for the `kv` argument.
     pub trait KVs<'a> {
         fn into_kvs(self) -> Option<&'a [(&'a str, &'a super::Value<'a>)]>;
     }
 }
 
-// Types for the `kv` argument.
+// Types for the `target` argument.
 
+/// Caller specified target explicitly.
+impl<'a> Target<'a> for &'a str {
+    #[inline]
+    fn into_target(self, _module_path: &'a str) -> &'a str {
+        self
+    }
+}
+
+/// Caller did not specified target.
+impl<'a> Target<'a> for () {
+    #[inline]
+    fn into_target(self, module_path: &'a str) -> &'a str {
+        module_path
+    }
+}
+
+// Types for the `kvs` argument.
+
+/// Caller specified key-value data explicitly.
 impl<'a> KVs<'a> for &'a [(&'a str, &'a Value<'a>)] {
     #[inline]
     fn into_kvs(self) -> Option<&'a [(&'a str, &'a Value<'a>)]> {
@@ -27,6 +57,7 @@ impl<'a> KVs<'a> for &'a [(&'a str, &'a Value<'a>)] {
     }
 }
 
+/// Caller did not specify key-value data.
 impl<'a> KVs<'a> for () {
     #[inline]
     fn into_kvs(self) -> Option<&'a [(&'a str, &'a Value<'a>)]> {
@@ -34,13 +65,61 @@ impl<'a> KVs<'a> for () {
     }
 }
 
+// Types for the `level` argument.
+
+/// The log level is dynamically determined.
+impl LevelTrait for Level {
+    #[inline]
+    fn into_level(self) -> Level {
+        self
+    }
+}
+
+macro_rules! define_static_levels {
+    ($(($name:ident, $level:ident),)*) => {$(
+        #[derive(Clone, Copy, Debug)]
+        pub struct $name;
+
+        /// The log level is statically determined.
+        impl LevelTrait for $name {
+            #[inline]
+            fn into_level(self) -> Level {
+                Level::$level
+            }
+        }
+
+        impl PartialEq<LevelFilter> for $name {
+            #[inline]
+            fn eq(&self, other: &LevelFilter) -> bool {
+                self.into_level().eq(other)
+            }
+        }
+
+        impl PartialOrd<LevelFilter> for $name {
+            #[inline]
+            fn partial_cmp(&self, other: &LevelFilter) -> Option<Ordering> {
+                self.into_level().partial_cmp(other)
+            }
+        }
+    )*};
+}
+
+define_static_levels![
+    (LevelError, Error),
+    (LevelWarn, Warn),
+    (LevelInfo, Info),
+    (LevelDebug, Debug),
+    (LevelTrace, Trace),
+];
+
 // Log implementation.
 
 fn log_impl(
     args: Arguments,
-    level: Level,
-    &(target, module_path, file): &(&str, &'static str, &'static str),
+    &(module_path, file): &'static (&'static str, &'static str),
     line: u32,
+    target: &str,
+    level: Level,
     kvs: Option<&[(&str, &Value)]>,
 ) {
     #[cfg(not(feature = "kv_unstable"))]
@@ -66,20 +145,27 @@ fn log_impl(
     crate::logger().log(&builder.build());
 }
 
-pub fn log<'a, K>(
+// `#[inline(never)]` is used to prevent compiler from inlining this function so that the binary size could be kept as
+// small as possible.
+#[inline(never)]
+pub fn log<'a, T, L, K>(
     args: Arguments,
-    level: Level,
-    target_module_path_and_file: &(&str, &'static str, &'static str),
+    module_path_and_file: &'static (&'static str, &'static str),
     line: u32,
+    target: T,
+    level: L,
     kvs: K,
 ) where
+    T: Target<'a>,
+    L: LevelTrait,
     K: KVs<'a>,
 {
     log_impl(
         args,
-        level,
-        target_module_path_and_file,
+        module_path_and_file,
         line,
+        target.into_target(module_path_and_file.0),
+        level.into_level(),
         kvs.into_kvs(),
     )
 }


### PR DESCRIPTION
This PR intends to optimize binary size by avoiding passing target and level arguments if they can be determined statically.

I have rewritten the implementation of the log macros to parse each argument separately in order to map macro arguments to the underlying `__private_api::log` function arguments.

Here is the binary size result tested using <https://github.com/EFanZh/log/tree/binary-size-test/cargo-binstall>:

| opt-level | lto  | codegen-units | original size | optimized size | diff   |
| --------- | ---- | ------------- | ------------- | -------------- | ------ |
| 3         | off  |             1 |      15714240 |       15714240 |      0 |
| 3         | off  |            16 |      18257920 |       18257920 |      0 |
| 3         | thin |             1 |      16803704 |       16791416 | -12288 |
| 3         | thin |            16 |      19269592 |       19257304 | -12288 |
| 3         | fat  |             1 |      15415128 |       15402840 | -12288 |
| 3         | fat  |            16 |      16418616 |       16398136 | -20480 |
| "z"       | off  |             1 |      11921344 |       11917248 |  -4096 |
| "z"       | off  |            16 |      13867008 |       13871104 |   4096 |
| "z"       | thin |             1 |      12806008 |       12801912 |  -4096 |
| "z"       | thin |            16 |      14108632 |       14104536 |  -4096 |
| "z"       | fat  |             1 |      10385240 |       10381144 |  -4096 |
| "z"       | fat  |            16 |      10893144 |       10889048 |  -4096 |

Here is the runtime performance benchmark result tested using <https://github.com/EFanZh/log/tree/benchmark>.

```
original  => cycles: 1110, instructions: 70, wall time: 310ns.
optimized => cycles: 1126, instructions: 70, wall time: 280ns.
```

Note that I have added `#[inline(never)]` to the `log` function to prevent the compiler from calling `log_impl` directly which could affect the optimization. Without `#[inline(never)]`, the binary size change will be:

| opt-level | lto  | codegen-units | original size | optimized size | diff   |
| --------- | ---- | ------------- | ------------- | -------------- | ------ |
| 3         | off  |             1 |      15714240 |       15714240 |      0 |
| 3         | off  |            16 |      18257920 |       18257920 |      0 |
| 3         | thin |             1 |      16803704 |       16803704 |      0 |
| 3         | thin |            16 |      19269592 |       19261400 |  -8192 |
| 3         | fat  |             1 |      15415128 |       15419224 |   4096 |
| 3         | fat  |            16 |      16418616 |       16418616 |      0 |
| "z"       | off  |             1 |      11921344 |       11921344 |      0 |
| "z"       | off  |            16 |      13867008 |       13871104 |   4096 |
| "z"       | thin |             1 |      12806008 |       12801912 |  -4096 |
| "z"       | thin |            16 |      14108632 |       14104536 |  -4096 |
| "z"       | fat  |             1 |      10385240 |       10385240 |      0 |
| "z"       | fat  |            16 |      10893144 |       10889048 |  -4096 |

Personally, I prefer keeping `#[inline(never)]`, since it has better binary size, and no significant performance cost.