### PR TITLE
Rewrite `set_logger` function to use `std::sync::Once` on std

### DIFF
--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -2,8 +2,8 @@
 
 use self::sealed::KVs;
 use crate::{Level, Metadata, Record};
-use std::fmt::Arguments;
-pub use std::{file, format_args, line, module_path, stringify};
+use core::fmt::Arguments;
+pub use core::{file, format_args, line, module_path, stringify};
 
 #[cfg(feature = "kv_unstable")]
 pub type Value<'a> = dyn crate::kv::value::ToValue + 'a;

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// An error encountered while working with structured data.
 #[derive(Debug)]

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -1,7 +1,7 @@
 //! Structured keys.
 
-use std::borrow::Borrow;
-use std::fmt;
+use core::borrow::Borrow;
+use core::fmt;
 
 /// A type that can be converted into a [`Key`](struct.Key.html).
 pub trait ToKey {

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -1,7 +1,7 @@
 //! Sources for key-value pairs.
 
 use crate::kv::{Error, Key, ToKey, ToValue, Value};
-use std::fmt;
+use core::fmt;
 
 /// A source of key-value pairs.
 ///

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -1,6 +1,6 @@
 //! Structured values.
 
-use std::fmt;
+use core::fmt;
 
 pub use crate::kv::Error;
 
@@ -421,13 +421,13 @@ impl ToValue for i128 {
     }
 }
 
-impl ToValue for std::num::NonZeroU128 {
+impl ToValue for core::num::NonZeroU128 {
     fn to_value(&self) -> Value {
         Value::from(self)
     }
 }
 
-impl ToValue for std::num::NonZeroI128 {
+impl ToValue for core::num::NonZeroI128 {
     fn to_value(&self) -> Value {
         Value::from(self)
     }
@@ -451,17 +451,17 @@ impl<'v> From<&'v i128> for Value<'v> {
     }
 }
 
-impl<'v> From<&'v std::num::NonZeroU128> for Value<'v> {
-    fn from(v: &'v std::num::NonZeroU128) -> Value<'v> {
+impl<'v> From<&'v core::num::NonZeroU128> for Value<'v> {
+    fn from(v: &'v core::num::NonZeroU128) -> Value<'v> {
         // SAFETY: `NonZeroU128` and `u128` have the same ABI
-        Value::from_value_bag(unsafe { &*(v as *const std::num::NonZeroU128 as *const u128) })
+        Value::from_value_bag(unsafe { &*(v as *const core::num::NonZeroU128 as *const u128) })
     }
 }
 
-impl<'v> From<&'v std::num::NonZeroI128> for Value<'v> {
-    fn from(v: &'v std::num::NonZeroI128) -> Value<'v> {
+impl<'v> From<&'v core::num::NonZeroI128> for Value<'v> {
+    fn from(v: &'v core::num::NonZeroI128) -> Value<'v> {
         // SAFETY: `NonZeroI128` and `i128` have the same ABI
-        Value::from_value_bag(unsafe { &*(v as *const std::num::NonZeroI128 as *const i128) })
+        Value::from_value_bag(unsafe { &*(v as *const core::num::NonZeroI128 as *const i128) })
     }
 }
 
@@ -504,14 +504,14 @@ macro_rules! impl_to_value_primitive {
 macro_rules! impl_to_value_nonzero_primitive {
     ($($into_ty:ident,)*) => {
         $(
-            impl ToValue for std::num::$into_ty {
+            impl ToValue for ::core::num::$into_ty {
                 fn to_value(&self) -> Value {
                     Value::from(self.get())
                 }
             }
 
-            impl<'v> From<std::num::$into_ty> for Value<'v> {
-                fn from(value: std::num::$into_ty) -> Self {
+            impl<'v> From<::core::num::$into_ty> for Value<'v> {
+                fn from(value: ::core::num::$into_ty) -> Self {
                     Value::from(value.get())
                 }
             }
@@ -783,11 +783,11 @@ pub(crate) mod tests {
             Value::from(32u32),
             Value::from(64u64),
             Value::from(1usize),
-            Value::from(std::num::NonZeroU8::new(8).unwrap()),
-            Value::from(std::num::NonZeroU16::new(16).unwrap()),
-            Value::from(std::num::NonZeroU32::new(32).unwrap()),
-            Value::from(std::num::NonZeroU64::new(64).unwrap()),
-            Value::from(std::num::NonZeroUsize::new(1).unwrap()),
+            Value::from(core::num::NonZeroU8::new(8).unwrap()),
+            Value::from(core::num::NonZeroU16::new(16).unwrap()),
+            Value::from(core::num::NonZeroU32::new(32).unwrap()),
+            Value::from(core::num::NonZeroU64::new(64).unwrap()),
+            Value::from(core::num::NonZeroUsize::new(1).unwrap()),
         ]
         .into_iter()
     }
@@ -799,11 +799,11 @@ pub(crate) mod tests {
             Value::from(-32i32),
             Value::from(-64i64),
             Value::from(-1isize),
-            Value::from(std::num::NonZeroI8::new(-8).unwrap()),
-            Value::from(std::num::NonZeroI16::new(-16).unwrap()),
-            Value::from(std::num::NonZeroI32::new(-32).unwrap()),
-            Value::from(std::num::NonZeroI64::new(-64).unwrap()),
-            Value::from(std::num::NonZeroIsize::new(-1).unwrap()),
+            Value::from(core::num::NonZeroI8::new(-8).unwrap()),
+            Value::from(core::num::NonZeroI16::new(-16).unwrap()),
+            Value::from(core::num::NonZeroI32::new(-32).unwrap()),
+            Value::from(core::num::NonZeroI64::new(-64).unwrap()),
+            Value::from(core::num::NonZeroIsize::new(-1).unwrap()),
         ]
         .into_iter()
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -8,8 +8,9 @@ use serde::ser::{Serialize, Serializer};
 
 use crate::{Level, LevelFilter, LOG_LEVEL_NAMES};
 
-use std::fmt;
-use std::str::{self, FromStr};
+use core::fmt;
+use core::str;
+use core::str::FromStr;
 
 // The Deserialize impls are handwritten to be case insensitive using FromStr.
 


### PR DESCRIPTION
I split implementations for 3 cases:
* When std is available, use standard locking primitive.
* When std is not available but there is atomics with pointer size, use spinlock
* If there is no atomic with pointer size, assume that there is no threads and use `Cell`.

I think, this separation makes easier to understand what is happening in each case.

Also:
* Replaced `SeqCst` by weaker orderings because they are enough
* Removed alias from `core` to `std` because it is confusing