### PR TITLE
Get structured logging API ready for stabilization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,10 +44,10 @@ jobs:
     - run: cargo test --verbose --all-features
     - run: cargo test --verbose --features serde
     - run: cargo test --verbose --features std
-    - run: cargo test --verbose --features kv_unstable
-    - run: cargo test --verbose --features kv_unstable_sval
-    - run: cargo test --verbose --features kv_unstable_serde
-    - run: cargo test --verbose --features "kv_unstable kv_unstable_std kv_unstable_sval kv_unstable_serde"
+    - run: cargo test --verbose --features kv
+    - run: cargo test --verbose --features kv_sval
+    - run: cargo test --verbose --features kv_serde
+    - run: cargo test --verbose --features "kv kv_std kv_sval kv_serde"
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
 
@@ -103,12 +103,12 @@ jobs:
         run: |
           rustup update nightly --no-self-update
           rustup default nightly
-      - run: cargo build --verbose -Z avoid-dev-deps --features kv_unstable
-      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable std"
-      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_sval"
-      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_serde"
-      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_std"
-      - run: cargo build --verbose -Z avoid-dev-deps --features "kv_unstable kv_unstable_sval kv_unstable_serde"
+      - run: cargo build --verbose -Z avoid-dev-deps --features kv
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv std"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv kv_sval"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv kv_serde"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv kv_std"
+      - run: cargo build --verbose -Z avoid-dev-deps --features "kv kv_sval kv_serde"
 
   minimalv:
     name: Minimal versions
@@ -119,12 +119,12 @@ jobs:
         run: |
           rustup update nightly --no-self-update
           rustup default nightly
-      - run: cargo build --verbose -Z minimal-versions --features kv_unstable
-      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable std"
-      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_sval"
-      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_serde"
-      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_std"
-      - run: cargo build --verbose -Z minimal-versions --features "kv_unstable kv_unstable_sval kv_unstable_serde"
+      - run: cargo build --verbose -Z minimal-versions --features kv
+      - run: cargo build --verbose -Z minimal-versions --features "kv std"
+      - run: cargo build --verbose -Z minimal-versions --features "kv kv_sval"
+      - run: cargo build --verbose -Z minimal-versions --features "kv kv_serde"
+      - run: cargo build --verbose -Z minimal-versions --features "kv kv_std"
+      - run: cargo build --verbose -Z minimal-versions --features "kv kv_sval kv_serde"
 
   msrv:
     name: MSRV
@@ -135,7 +135,9 @@ jobs:
         run: |
           rustup update 1.60.0 --no-self-update
           rustup default 1.60.0
-      - run: cargo test --verbose --manifest-path tests/Cargo.toml
+      - run: |
+          cargo test --verbose --manifest-path tests/Cargo.toml
+          cargo test --verbose --manifest-path tests/Cargo.toml --features kv
 
   embedded:
     name: Embedded

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ kv_sval = ["kv", "value-bag/sval", "sval", "sval_ref"]
 kv_std = ["std", "kv", "value-bag/error"]
 kv_serde = ["kv_std", "value-bag/serde", "serde"]
 
-# Legacy: use `kv_*` instead
+# Deprecated: use `kv_*` instead
+# These `*_unstable` features will be removed in a future release
 kv_unstable = ["kv"]
 kv_unstable_sval = ["kv_sval"]
 kv_unstable_std = ["kv_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["std", "serde", "kv_unstable_std", "kv_unstable_sval", "kv_unstable_serde"]
+features = ["std", "serde", "kv_std", "kv_sval", "kv_serde"]
 
 [[test]]
 name = "filters"
@@ -46,12 +46,16 @@ release_max_level_trace = []
 
 std = []
 
-# requires the latest stable
-# this will have a tighter MSRV before stabilization
-kv_unstable = []
-kv_unstable_sval = ["kv_unstable", "value-bag/sval", "sval", "sval_ref"]
-kv_unstable_std = ["std", "kv_unstable", "value-bag/error"]
-kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]
+kv = []
+kv_sval = ["kv", "value-bag/sval", "sval", "sval_ref"]
+kv_std = ["std", "kv", "value-bag/error"]
+kv_serde = ["kv_std", "value-bag/serde", "serde"]
+
+# Legacy: use `kv_*` instead
+kv_unstable = ["kv"]
+kv_unstable_sval = ["kv_sval"]
+kv_unstable_std = ["kv_std"]
+kv_unstable_serde = ["kv_serde"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ value-bag = { version = "1.4", optional = true, default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_test = "1.0"
 sval = { version = "2.1" }
 sval_derive = { version = "2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ std = []
 
 # requires the latest stable
 # this will have a tighter MSRV before stabilization
-kv_unstable = ["value-bag"]
+kv_unstable = []
 kv_unstable_sval = ["kv_unstable", "value-bag/sval", "sval", "sval_ref"]
 kv_unstable_std = ["std", "kv_unstable", "value-bag/error"]
 kv_unstable_serde = ["kv_unstable_std", "value-bag/serde", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,10 +53,10 @@ kv_serde = ["kv_std", "value-bag/serde", "serde"]
 
 # Deprecated: use `kv_*` instead
 # These `*_unstable` features will be removed in a future release
-kv_unstable = ["kv"]
-kv_unstable_sval = ["kv_sval"]
-kv_unstable_std = ["kv_std"]
-kv_unstable_serde = ["kv_serde"]
+kv_unstable = ["kv", "value-bag"]
+kv_unstable_sval = ["kv_sval", "kv_unstable"]
+kv_unstable_std = ["kv_std", "kv_unstable"]
+kv_unstable_serde = ["kv_serde", "kv_unstable_std"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pub fn shave_the_yak(yak: &mut Yak) {
                 break;
             }
             Err(err) => {
-                warn!(err:error = err; "Unable to locate a razor, retrying");
+                warn!(err:err; "Unable to locate a razor, retrying");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -106,17 +106,22 @@ If you enable the `kv` feature, you can associate structured data with your log 
 use log::{info, trace, warn};
 
 pub fn shave_the_yak(yak: &mut Yak) {
-    trace!(target = "yak_events", yak:serde = yak; "Commencing yak shaving");
+    // `yak:serde` will capture `yak` using its `serde::Serialize` impl
+    //
+    // You could also use `:?` for `Debug`, or `:%` for `Display`. For a
+    // full list, see the `log` crate documentation
+    trace!(target = "yak_events", yak:serde; "Commencing yak shaving");
 
     loop {
         match find_a_razor() {
             Ok(razor) => {
-                info!(razor = razor; "Razor located");
+                info!(razor; "Razor located");
                 yak.shave(razor);
                 break;
             }
-            Err(err) => {
-                warn!(err:err; "Unable to locate a razor, retrying");
+            Err(e) => {
+                // `e:err` will capture `e` using its `std::error::Error` impl
+                warn!(e:err; "Unable to locate a razor, retrying");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ The executable itself may use the `log` crate to log as well.
 If you enable the `kv_unstable` feature, you can associate structured data with your log records:
 
 ```rust
-use log::{info, trace, warn, as_serde, as_error};
+use log::{info, trace, warn};
 
 pub fn shave_the_yak(yak: &mut Yak) {
-    trace!(target = "yak_events", yak = as_serde!(yak); "Commencing yak shaving");
+    trace!(target = "yak_events", yak:serde = yak; "Commencing yak shaving");
 
     loop {
         match find_a_razor() {
@@ -116,7 +116,7 @@ pub fn shave_the_yak(yak: &mut Yak) {
                 break;
             }
             Err(err) => {
-                warn!(err = as_error!(err); "Unable to locate a razor, retrying");
+                warn!(err:error = err; "Unable to locate a razor, retrying");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The executable itself may use the `log` crate to log as well.
 
 ## Structured logging
 
-If you enable the `kv_unstable` feature, you can associate structured data with your log records:
+If you enable the `kv` feature, you can associate structured data with your log records:
 
 ```rust
 use log::{info, trace, warn};

--- a/benches/value.rs
+++ b/benches/value.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "kv_unstable")]
+#![cfg(feature = "kv")]
 #![feature(test)]
 
 use log::kv::Value;

--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -5,7 +5,7 @@ use crate::{Level, Metadata, Record};
 use std::fmt::Arguments;
 pub use std::{file, format_args, line, module_path, stringify};
 
-#[cfg(not(feature = "kv_unstable"))]
+#[cfg(not(feature = "kv"))]
 pub type Value<'a> = &'a str;
 
 mod sealed {
@@ -40,11 +40,9 @@ fn log_impl(
     line: u32,
     kvs: Option<&[(&str, Value)]>,
 ) {
-    #[cfg(not(feature = "kv_unstable"))]
+    #[cfg(not(feature = "kv"))]
     if kvs.is_some() {
-        panic!(
-            "key-value support is experimental and must be enabled using the `kv_unstable` feature"
-        )
+        panic!("key-value support is experimental and must be enabled using the `kv` feature")
     }
 
     let mut builder = Record::builder();
@@ -57,7 +55,7 @@ fn log_impl(
         .file_static(Some(file))
         .line(Some(line));
 
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     builder.key_values(&kvs);
 
     crate::logger().log(&builder.build());
@@ -85,7 +83,7 @@ pub fn enabled(level: Level, target: &str) -> bool {
     crate::logger().enabled(&Metadata::builder().level(level).target(target).build())
 }
 
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 mod kv_support {
     use crate::kv;
 
@@ -107,21 +105,21 @@ mod kv_support {
         Value::from_display(v)
     }
 
-    #[cfg(feature = "kv_unstable_std")]
+    #[cfg(feature = "kv_std")]
     pub fn capture_error<'a>(v: &'a (dyn std::error::Error + 'static)) -> Value<'a> {
         Value::from_dyn_error(v)
     }
 
-    #[cfg(feature = "kv_unstable_sval")]
+    #[cfg(feature = "kv_sval")]
     pub fn capture_sval<'a, V: sval::Value + ?Sized>(v: &'a &'a V) -> Value<'a> {
         Value::from_sval(v)
     }
 
-    #[cfg(feature = "kv_unstable_serde")]
+    #[cfg(feature = "kv_serde")]
     pub fn capture_serde<'a, V: serde::Serialize + ?Sized>(v: &'a &'a V) -> Value<'a> {
         Value::from_serde(v)
     }
 }
 
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 pub use self::kv_support::*;

--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -93,7 +93,11 @@ mod kv_support {
 
     pub type Value<'a> = kv::Value<'a>;
 
-    pub fn capture_to_value<'a, V: kv::value::ToValue + ?Sized>(v: &'a &'a V) -> Value<'a> {
+    // NOTE: Many functions here accept a double reference &&V
+    // This is so V itself can be ?Sized, while still letting us
+    // erase it to some dyn Trait (because &T is sized)
+
+    pub fn capture_to_value<'a, V: kv::ToValue + ?Sized>(v: &'a &'a V) -> Value<'a> {
         v.to_value()
     }
 

--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -87,8 +87,6 @@ pub fn enabled(level: Level, target: &str) -> bool {
 
 #[cfg(feature = "kv_unstable")]
 mod kv_support {
-    use super::*;
-
     use crate::kv;
 
     pub type Value<'a> = kv::Value<'a>;

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -37,9 +37,9 @@ impl Error {
     pub(super) fn into_value(self) -> crate::kv::value::inner::Error {
         match self.inner {
             Inner::Value(err) => err,
-            #[cfg(feature = "kv_unstable_std")]
+            #[cfg(feature = "kv_std")]
             _ => crate::kv::value::inner::Error::boxed(self),
-            #[cfg(not(feature = "kv_unstable_std"))]
+            #[cfg(not(feature = "kv_std"))]
             _ => crate::kv::value::inner::Error::msg("error inspecting a value"),
         }
     }

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::kv::value;
+
 /// An error encountered while working with structured data.
 #[derive(Debug)]
 pub struct Error {
@@ -11,7 +13,7 @@ enum Inner {
     #[cfg(feature = "std")]
     Boxed(std_support::BoxedError),
     Msg(&'static str),
-    Value(value_bag::Error),
+    Value(value::inner::Error),
     Fmt,
 }
 
@@ -23,21 +25,21 @@ impl Error {
         }
     }
 
-    // Not public so we don't leak the `value_bag` API
-    pub(super) fn from_value(err: value_bag::Error) -> Self {
+    // Not public so we don't leak the `value::inner` API
+    pub(super) fn from_value(err: value::inner::Error) -> Self {
         Error {
             inner: Inner::Value(err),
         }
     }
 
-    // Not public so we don't leak the `value_bag` API
-    pub(super) fn into_value(self) -> value_bag::Error {
+    // Not public so we don't leak the `value::inner` API
+    pub(super) fn into_value(self) -> value::inner::Error {
         match self.inner {
             Inner::Value(err) => err,
             #[cfg(feature = "kv_unstable_std")]
-            _ => value_bag::Error::boxed(self),
+            _ => value::inner::Error::boxed(self),
             #[cfg(not(feature = "kv_unstable_std"))]
-            _ => value_bag::Error::msg("error inspecting a value"),
+            _ => value::inner::Error::msg("error inspecting a value"),
         }
     }
 }

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -30,7 +30,7 @@ impl ToKey for str {
     }
 }
 
-/// A key in a user-defined attribute.
+/// A key in a key-value.
 // These impls must only be based on the as_str() representation of the key
 // If a new field (such as an optional index) is added to the key they must not affect comparison
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -93,7 +93,7 @@ mod std_support {
     }
 }
 
-#[cfg(feature = "kv_unstable_sval")]
+#[cfg(feature = "kv_sval")]
 mod sval_support {
     use super::*;
 
@@ -116,7 +116,7 @@ mod sval_support {
     }
 }
 
-#[cfg(feature = "kv_unstable_serde")]
+#[cfg(feature = "kv_serde")]
 mod serde_support {
     use super::*;
 

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -30,7 +30,7 @@ impl ToKey for str {
     }
 }
 
-/// A key in a structured key-value pair.
+/// A key in a user-defined attribute.
 // These impls must only be based on the as_str() representation of the key
 // If a new field (such as an optional index) is added to the key they must not affect comparison
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -29,6 +29,15 @@
 //! info!(a = 1; "Something of interest");
 //! ```
 //!
+//! Key-values support the same shorthand identifer syntax as `format_args`:
+//!
+//! ```
+//! # use log::info;
+//! let a = 1;
+//!
+//! info!(a; "Something of interest");
+//! ```
+//!
 //! Values are capturing using the [`ToValue`] trait by default. To capture a value
 //! using a different trait implementation, use a modifier after its key. Here's how
 //! the same example can capture `a` using its `Debug` implementation instead:
@@ -44,7 +53,7 @@
 //! - `:debug` will capture the value using `Debug`.
 //! - `:%` will capture the value using `Display`.
 //! - `:display` will capture the value using `Display`.
-//! - `:error` will capture the value using `std::error::Error` (requires the `kv_std` feature).
+//! - `:err` will capture the value using `std::error::Error` (requires the `kv_std` feature).
 //! - `:sval` will capture the value using `sval::Value` (requires the `kv_sval` feature).
 //! - `:serde` will capture the value using `serde::Serialize` (requires the `kv_serde` feature).
 //!

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -71,18 +71,18 @@
 //! # }
 //! ```
 //!
-//! All key-values can also be enumerated using a [`source::Visitor`]:
+//! All key-values can also be enumerated using a [`VisitSource`]:
 //!
 //! ```
 //! # fn main() -> Result<(), log::kv::Error> {
 //! # let record = log::Record::builder().key_values(&[("a", 1), ("b", 2), ("c", 3)]).build();
 //! use std::collections::BTreeMap;
 //!
-//! use log::kv::{self, Source, Key, Value, source::Visitor};
+//! use log::kv::{self, Source, Key, Value, VisitSource};
 //!
 //! struct Collect<'kvs>(BTreeMap<Key<'kvs>, Value<'kvs>>);
 //!
-//! impl<'kvs> Visitor<'kvs> for Collect<'kvs> {
+//! impl<'kvs> VisitSource<'kvs> for Collect<'kvs> {
 //!     fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), kv::Error> {
 //!         self.0.insert(key, value);
 //!
@@ -125,17 +125,17 @@
 //! # }
 //! ```
 //!
-//! Values also have their own [`value::Visitor`] type. Visitors are a lightweight
+//! Values also have their own [`VisitValue`] type. Value visitors are a lightweight
 //! API for working with primitives types:
 //!
 //! ```
 //! # fn main() -> Result<(), log::kv::Error> {
-//! use log::kv::{self, Source, Key, value::Visitor};
+//! use log::kv::{self, Source, Key, VisitValue};
 //! # let record = log::Record::builder().key_values(&[("a", 1)]).build();
 //!
 //! struct IsNumeric(bool);
 //!
-//! impl<'kvs> Visitor<'kvs> for IsNumeric {
+//! impl<'kvs> VisitValue<'kvs> for IsNumeric {
 //!     fn visit_any(&mut self, _value: kv::Value) -> Result<(), kv::Error> {
 //!         self.0 = false;
 //!         Ok(())
@@ -230,12 +230,9 @@
 mod error;
 mod key;
 pub mod source;
-
 pub mod value;
 
 pub use self::error::Error;
 pub use self::key::{Key, ToKey};
-pub use self::source::{Source, Visitor};
-
-#[doc(inline)]
-pub use self::value::{ToValue, Value};
+pub use self::source::{Source, VisitSource};
+pub use self::value::{ToValue, Value, VisitValue};

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -11,6 +11,62 @@
 //! [dependencies.log]
 //! features = ["kv_unstable"]
 //! ```
+//!
+//! # Structured logging in `log`
+//!
+//! Structured logging enhances traditional text-based log records with user-defined
+//! attributes. Structured logs can be analyzed using a variety of tranditional
+//! data processing techniques, without needing to find and parse attributes from
+//! unstructured text first.
+//!
+//! In `log`, user-defined attributes are part of a [`Source`] on the [`LogRecord`].
+//! Each attribute is a pair of [`Key`] and [`Value`]. Keys are strings and values
+//! are a datum of any type that can be formatted or serialized. Simple types like
+//! strings, booleans, and numbers are supported, as well as arbitrarily complex
+//! structures involving nested objects and sequences.
+//!
+//! ## Adding attributes to log records
+//!
+//! Attributes appear after the message format in the `log!` macros:
+//!
+//! ```
+//! ..
+//! ```
+//!
+//! ## Working with attributes on log records
+//!
+//! Use the [`LogRecord::source`] method to access user-defined attributes.
+//! Individual attributes can be pulled from the source:
+//!
+//! ```
+//! ..
+//! ```
+//!
+//! This is convenient when an attribute of interest is known in advance.
+//! All attributes can also be enumerated using a [`Visitor`]:
+//!
+//! ```
+//! ..
+//! ```
+//!
+//! [`Value`]s in attributes have methods for conversions to common types:
+//!
+//! ```
+//! ..
+//! ```
+//!
+//! Values also have their own [`value::Visitor`] type:
+//!
+//! ```
+//! ..
+//! ```
+//!
+//! Visitors on values are lightweight and suitable for detecting primitive types.
+//! To serialize a value, you can also use either `serde` or `sval`. If you're
+//! in a no-std environment, you can use `sval`. In other cases, you can use `serde`.
+//!
+//! Values can also always be formatted using the standard `Debug` and `Display`
+//! traits.
 
 mod error;
 mod key;

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,4 +1,4 @@
-//! **UNSTABLE:** Structured key-value pairs.
+//! **UNSTABLE:** Structured logging.
 //!
 //! This module is unstable and breaking changes may be made
 //! at any time. See [the tracking issue](https://github.com/rust-lang-nursery/log/issues/328)
@@ -62,11 +62,20 @@
 //! ```
 //!
 //! Visitors on values are lightweight and suitable for detecting primitive types.
-//! To serialize a value, you can also use either `serde` or `sval`. If you're
-//! in a no-std environment, you can use `sval`. In other cases, you can use `serde`.
+//! To serialize a value, you can also use either `serde` or `sval`:
+//! 
+//! ```
+//! ..
+//! ```
+//! 
+//! If you're in a no-std environment, you can use `sval`. In other cases, you can use `serde`.
 //!
 //! Values can also always be formatted using the standard `Debug` and `Display`
-//! traits.
+//! traits:
+//! 
+//! ```
+//! ..
+//! ```
 
 mod error;
 mod key;

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -66,6 +66,7 @@
 //! // info!(a = 1; "Something of interest");
 //!
 //! let a: Value = record.key_values().get(Key::from("a")).unwrap();
+//! assert_eq!(1, a.to_i64().unwrap());
 //! # Ok(())
 //! # }
 //! ```

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -236,10 +236,21 @@
 
 mod error;
 mod key;
+
+#[cfg(not(feature = "kv_unstable"))]
 mod source;
+#[cfg(not(feature = "kv_unstable"))]
 mod value;
 
 pub use self::error::Error;
 pub use self::key::{Key, ToKey};
 pub use self::source::{Source, VisitSource};
 pub use self::value::{ToValue, Value, VisitValue};
+
+#[cfg(feature = "kv_unstable")]
+pub mod source;
+#[cfg(feature = "kv_unstable")]
+pub mod value;
+
+#[cfg(feature = "kv_unstable")]
+pub use self::source::Visitor;

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -45,13 +45,13 @@
 //! 
 //! The following capturing modifiers are supported:
 //! 
-//! - `:?`: `Debug`.
-//! - `:debug`: `Debug`.
-//! - `:%`: `Display`.
-//! - `:display`: `Display`.
-//! - `:error`: `std::error::Error` (requires the `kv_unstable_error` feature).
-//! - `:sval`: `sval::Value` (requires the `kv_unstable_sval` feature).
-//! - `:serde`: `serde::Serialize` (requires the `kv_unstable_serde` feature).
+//! - `:?` will capture the value using `Debug`.
+//! - `:debug` will capture the value using `Debug`.
+//! - `:%` will capture the value using `Display`.
+//! - `:display` will capture the value using `Display`.
+//! - `:error` will capture the value using `std::error::Error` (requires the `kv_unstable_error` feature).
+//! - `:sval` will capture the value using `sval::Value` (requires the `kv_unstable_sval` feature).
+//! - `:serde` will capture the value using `serde::Serialize` (requires the `kv_unstable_serde` feature).
 //!
 //! ## Working with key-values on log records
 //!

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,15 +1,11 @@
-//! **UNSTABLE:** Structured logging.
+//! Structured logging.
 //!
-//! This module is unstable and breaking changes may be made
-//! at any time. See [the tracking issue](https://github.com/rust-lang-nursery/log/issues/328)
-//! for more details.
-//!
-//! Add the `kv_unstable` feature to your `Cargo.toml` to enable
+//! Add the `kv` feature to your `Cargo.toml` to enable
 //! this module:
 //!
 //! ```toml
 //! [dependencies.log]
-//! features = ["kv_unstable"]
+//! features = ["kv"]
 //! ```
 //!
 //! # Structured logging in `log`
@@ -48,9 +44,9 @@
 //! - `:debug` will capture the value using `Debug`.
 //! - `:%` will capture the value using `Display`.
 //! - `:display` will capture the value using `Display`.
-//! - `:error` will capture the value using `std::error::Error` (requires the `kv_unstable_std` feature).
-//! - `:sval` will capture the value using `sval::Value` (requires the `kv_unstable_sval` feature).
-//! - `:serde` will capture the value using `serde::Serialize` (requires the `kv_unstable_serde` feature).
+//! - `:error` will capture the value using `std::error::Error` (requires the `kv_std` feature).
+//! - `:sval` will capture the value using `sval::Value` (requires the `kv_sval` feature).
+//! - `:serde` will capture the value using `serde::Serialize` (requires the `kv_serde` feature).
 //!
 //! ## Working with key-values on log records
 //!

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -20,8 +20,8 @@
 //! unstructured text first.
 //!
 //! In `log`, user-defined attributes are part of a [`Source`] on the log record.
-//! Each attribute is a key-value; a pair of [`Key`] and [`Value`]. Keys are strings 
-//! and values are a datum of any type that can be formatted or serialized. Simple types 
+//! Each attribute is a key-value; a pair of [`Key`] and [`Value`]. Keys are strings
+//! and values are a datum of any type that can be formatted or serialized. Simple types
 //! like strings, booleans, and numbers are supported, as well as arbitrarily complex
 //! structures involving nested objects and sequences.
 //!
@@ -36,14 +36,14 @@
 //! ## Working with key-values on log records
 //!
 //! Use the [`LogRecord::key_values`] method to access key-values.
-//! 
+//!
 //! Individual values can be pulled from the source by their key:
 //!
 //! ```
 //! # fn main() -> Result<(), log::kv::Error> {
 //! use log::kv::{Source, Key, Value};
 //! # let record = log::Record::builder().key_values(&[("a", 1)]).build();
-//! 
+//!
 //! // info!("Something of interest"; a = 1);
 //! let a: Value = record.key_values().get(Key::from("a")).unwrap();
 //! # Ok(())
@@ -56,28 +56,28 @@
 //! # fn main() -> Result<(), log::kv::Error> {
 //! # let record = log::Record::builder().key_values(&[("a", 1), ("b", 2), ("c", 3)]).build();
 //! use std::collections::BTreeMap;
-//! 
+//!
 //! use log::kv::{self, Source, Key, Value, source::Visitor};
-//! 
+//!
 //! struct Collect<'kvs>(BTreeMap<Key<'kvs>, Value<'kvs>>);
-//! 
+//!
 //! impl<'kvs> Visitor<'kvs> for Collect<'kvs> {
 //!     fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), kv::Error> {
 //!         self.0.insert(key, value);
-//! 
+//!
 //!         Ok(())
 //!     }
 //! }
-//! 
+//!
 //! let mut visitor = Collect(BTreeMap::new());
-//! 
+//!
 //! // info!("Something of interest"; a = 1, b = 2, c = 3);
 //! record.key_values().visit(&mut visitor)?;
-//! 
+//!
 //! let collected = visitor.0;
-//! 
+//!
 //! assert_eq!(
-//!     vec!["a", "b", "c"], 
+//!     vec!["a", "b", "c"],
 //!     collected
 //!         .keys()
 //!         .map(|k| k.as_str())
@@ -93,10 +93,10 @@
 //! # fn main() -> Result<(), log::kv::Error> {
 //! use log::kv::{Source, Key};
 //! # let record = log::Record::builder().key_values(&[("a", 1)]).build();
-//! 
+//!
 //! // info!("Something of interest"; a = 1);
 //! let a = record.key_values().get(Key::from("a")).unwrap();
-//! 
+//!
 //! assert_eq!(1, a.to_i64().unwrap());
 //! # Ok(())
 //! # }
@@ -109,9 +109,9 @@
 //! # fn main() -> Result<(), log::kv::Error> {
 //! use log::kv::{self, Source, Key, value::Visitor};
 //! # let record = log::Record::builder().key_values(&[("a", 1)]).build();
-//! 
+//!
 //! struct IsNumeric(bool);
-//! 
+//!
 //! impl<'kvs> Visitor<'kvs> for IsNumeric {
 //!     fn visit_any(&mut self, _value: kv::Value) -> Result<(), kv::Error> {
 //!         self.0 = false;
@@ -143,23 +143,23 @@
 //!         Ok(())
 //!     }
 //! }
-//! 
+//!
 //! // info!("Something of interest"; a = 1);
 //! let a = record.key_values().get(Key::from("a")).unwrap();
-//! 
+//!
 //! let mut visitor = IsNumeric(false);
-//! 
+//!
 //! a.visit(&mut visitor)?;
-//! 
+//!
 //! let is_numeric = visitor.0;
-//! 
+//!
 //! assert!(is_numeric);
 //! # Ok(())
 //! # }
 //! ```
 //!
 //! To serialize a value to a format like JSON, you can also use either `serde` or `sval`:
-//! 
+//!
 //! ```
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # #[cfg(feature = "serde")]
@@ -169,16 +169,16 @@
 //! let data = Data { a: 1, b: true, c: "Some data" };
 //! # let source = [("a", log::kv::Value::from_serde(&data))];
 //! # let record = log::Record::builder().key_values(&source).build();
-//! 
+//!
 //! // info!("Something of interest"; a = data);
 //! let a = record.key_values().get(Key::from("a")).unwrap();
-//! 
+//!
 //! assert_eq!("{\"a\":1,\"b\":true,\"c\":\"Some data\"}", serde_json::to_string(&a)?);
 //! # }
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! The choice of serialization framework depends on the needs of the consumer.
 //! If you're in a no-std environment, you can use `sval`. In other cases, you can use `serde`.
 //! Log producers and log consumers don't need to agree on the serialization framework.
@@ -187,17 +187,17 @@
 //!
 //! Values can also always be formatted using the standard `Debug` and `Display`
 //! traits:
-//! 
+//!
 //! ```
 //! # use log::kv::Key;
 //! # #[derive(Debug)] struct Data { a: i32, b: bool, c: &'static str }
 //! let data = Data { a: 1, b: true, c: "Some data" };
 //! # let source = [("a", log::kv::Value::from_debug(&data))];
 //! # let record = log::Record::builder().key_values(&source).build();
-//! 
+//!
 //! // info!("Something of interest"; a = data);
 //! let a = record.key_values().get(Key::from("a")).unwrap();
-//! 
+//!
 //! assert_eq!("Data { a: 1, b: true, c: \"Some data\" }", format!("{a:?}"));
 //! ```
 

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -15,7 +15,7 @@
 //! # Structured logging in `log`
 //!
 //! Structured logging enhances traditional text-based log records with user-defined
-//! attributes. Structured logs can be analyzed using a variety of data processing 
+//! attributes. Structured logs can be analyzed using a variety of data processing
 //! techniques, without needing to find and parse attributes from unstructured text first.
 //!
 //! In `log`, user-defined attributes are part of a [`Source`] on the log record.
@@ -32,18 +32,18 @@
 //! # use log::info;
 //! info!(a = 1; "Something of interest");
 //! ```
-//! 
+//!
 //! Values are capturing using the [`ToValue`] trait by default. To capture a value
 //! using a different trait implementation, use a modifier after its key. Here's how
 //! the same example can capture `a` using its `Debug` implementation instead:
-//! 
+//!
 //! ```
 //! # use log::info;
 //! info!(a:? = 1; "Something of interest");
 //! ```
-//! 
+//!
 //! The following capturing modifiers are supported:
-//! 
+//!
 //! - `:?` will capture the value using `Debug`.
 //! - `:debug` will capture the value using `Debug`.
 //! - `:%` will capture the value using `Display`.

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -15,9 +15,8 @@
 //! # Structured logging in `log`
 //!
 //! Structured logging enhances traditional text-based log records with user-defined
-//! attributes. Structured logs can be analyzed using a variety of tranditional
-//! data processing techniques, without needing to find and parse attributes from
-//! unstructured text first.
+//! attributes. Structured logs can be analyzed using a variety of data processing 
+//! techniques, without needing to find and parse attributes from unstructured text first.
 //!
 //! In `log`, user-defined attributes are part of a [`Source`] on the log record.
 //! Each attribute is a key-value; a pair of [`Key`] and [`Value`]. Keys are strings
@@ -49,13 +48,13 @@
 //! - `:debug` will capture the value using `Debug`.
 //! - `:%` will capture the value using `Display`.
 //! - `:display` will capture the value using `Display`.
-//! - `:error` will capture the value using `std::error::Error` (requires the `kv_unstable_error` feature).
+//! - `:error` will capture the value using `std::error::Error` (requires the `kv_unstable_std` feature).
 //! - `:sval` will capture the value using `sval::Value` (requires the `kv_unstable_sval` feature).
 //! - `:serde` will capture the value using `serde::Serialize` (requires the `kv_unstable_serde` feature).
 //!
 //! ## Working with key-values on log records
 //!
-//! Use the [`LogRecord::key_values`] method to access key-values.
+//! Use the [`Record::key_values`](../struct.Record.html#method.key_values) method to access key-values.
 //!
 //! Individual values can be pulled from the source by their key:
 //!
@@ -75,7 +74,6 @@
 //!
 //! ```
 //! # fn main() -> Result<(), log::kv::Error> {
-//! # let record = log::Record::builder().key_values(&[("a", 1), ("b", 2), ("c", 3)]).build();
 //! use std::collections::BTreeMap;
 //!
 //! use log::kv::{self, Source, Key, Value, VisitSource};
@@ -92,6 +90,7 @@
 //!
 //! let mut visitor = Collect(BTreeMap::new());
 //!
+//! # let record = log::Record::builder().key_values(&[("a", 1), ("b", 2), ("c", 3)]).build();
 //! // info!(a = 1, b = 2, c = 3; "Something of interest");
 //!
 //! record.key_values().visit(&mut visitor)?;
@@ -189,11 +188,16 @@
 //! # #[cfg(feature = "serde")]
 //! # {
 //! # use log::kv::Key;
-//! # #[derive(serde::Serialize)] struct Data { a: i32, b: bool, c: &'static str }
+//! #[derive(serde::Serialize)]
+//! struct Data {
+//!     a: i32, b: bool,
+//!     c: &'static str,
+//! }
+//!
 //! let data = Data { a: 1, b: true, c: "Some data" };
+//!
 //! # let source = [("a", log::kv::Value::from_serde(&data))];
 //! # let record = log::Record::builder().key_values(&source).build();
-//!
 //! // info!(a = data; "Something of interest");
 //!
 //! let a = record.key_values().get(Key::from("a")).unwrap();
@@ -208,18 +212,24 @@
 //! If you're in a no-std environment, you can use `sval`. In other cases, you can use `serde`.
 //! Log producers and log consumers don't need to agree on the serialization framework.
 //! A value can be captured using its `serde::Serialize` implementation and still be serialized
-//! through `sval` without losing any structure.
+//! through `sval` without losing any structure or data.
 //!
 //! Values can also always be formatted using the standard `Debug` and `Display`
 //! traits:
 //!
 //! ```
 //! # use log::kv::Key;
-//! # #[derive(Debug)] struct Data { a: i32, b: bool, c: &'static str }
+//! # #[derive(Debug)]
+//! struct Data {
+//!     a: i32,
+//!     b: bool,
+//!     c: &'static str,
+//! }
+//!
 //! let data = Data { a: 1, b: true, c: "Some data" };
+//!
 //! # let source = [("a", log::kv::Value::from_debug(&data))];
 //! # let record = log::Record::builder().key_values(&source).build();
-//!
 //! // info!(a = data; "Something of interest");
 //!
 //! let a = record.key_values().get(Key::from("a")).unwrap();
@@ -229,8 +239,8 @@
 
 mod error;
 mod key;
-pub mod source;
-pub mod value;
+mod source;
+mod value;
 
 pub use self::error::Error;
 pub use self::key::{Key, ToKey};

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -363,7 +363,7 @@ mod std_support {
     mod tests {
         use std::collections::{BTreeMap, HashMap};
 
-        use crate::kv::value::tests::Token;
+        use crate::kv::value;
 
         use super::*;
 
@@ -377,7 +377,7 @@ mod std_support {
         fn get() {
             let source = vec![("a", 1), ("b", 2), ("a", 1)];
             assert_eq!(
-                Token::I64(1),
+                value::inner::Token::I64(1),
                 Source::get(&source, Key::from_str("a")).unwrap().to_token()
             );
 
@@ -393,7 +393,7 @@ mod std_support {
 
             assert_eq!(2, Source::count(&map));
             assert_eq!(
-                Token::I64(1),
+                value::inner::Token::I64(1),
                 Source::get(&map, Key::from_str("a")).unwrap().to_token()
             );
         }
@@ -406,7 +406,7 @@ mod std_support {
 
             assert_eq!(2, Source::count(&map));
             assert_eq!(
-                Token::I64(1),
+                value::inner::Token::I64(1),
                 Source::get(&map, Key::from_str("a")).unwrap().to_token()
             );
         }
@@ -415,7 +415,7 @@ mod std_support {
 
 #[cfg(test)]
 mod tests {
-    use crate::kv::value::tests::Token;
+    use crate::kv::value;
 
     use super::*;
 
@@ -452,11 +452,11 @@ mod tests {
     fn get() {
         let source = &[("a", 1), ("b", 2), ("a", 1)] as &[_];
         assert_eq!(
-            Token::I64(1),
+            value::inner::Token::I64(1),
             Source::get(source, Key::from_str("a")).unwrap().to_token()
         );
         assert_eq!(
-            Token::I64(2),
+            value::inner::Token::I64(2),
             Source::get(source, Key::from_str("b")).unwrap().to_token()
         );
         assert!(Source::get(&source, Key::from_str("c")).is_none());

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -81,8 +81,7 @@ pub trait Source {
     /// A source that knows the number of key-values upfront may provide a more
     /// efficient implementation.
     ///
-    /// A subsequent call to `visit` should yield the same number of key-values
-    /// to the visitor, unless that visitor fails part way through.
+    /// A subsequent call to `visit` should yield the same number of key-values.
     fn count(&self) -> usize {
         count_default(self)
     }

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -1,23 +1,31 @@
-//! Sources for key-value pairs.
+//! Sources for user-defined attributes.
 
 use crate::kv::{Error, Key, ToKey, ToValue, Value};
 use std::fmt;
 
-/// A source of key-value pairs.
+/// A source of user-defined attributes.
 ///
 /// The source may be a single pair, a set of pairs, or a filter over a set of pairs.
 /// Use the [`Visitor`](trait.Visitor.html) trait to inspect the structured data
 /// in a source.
+///
+/// # Examples
+///
+/// Enumerating the attributes in a source:
+///
+/// ```
+/// ..
+/// ```
 pub trait Source {
-    /// Visit key-value pairs.
+    /// Visit attributes.
     ///
-    /// A source doesn't have to guarantee any ordering or uniqueness of key-value pairs.
+    /// A source doesn't have to guarantee any ordering or uniqueness of attributes.
     /// If the given visitor returns an error then the source may early-return with it,
-    /// even if there are more key-value pairs.
+    /// even if there are more attributes.
     ///
     /// # Implementation notes
     ///
-    /// A source should yield the same key-value pairs to a subsequent visitor unless
+    /// A source should yield the same attributes to a subsequent visitor unless
     /// that visitor itself fails.
     fn visit<'kvs>(&'kvs self, visitor: &mut dyn Visitor<'kvs>) -> Result<(), Error>;
 
@@ -34,14 +42,14 @@ pub trait Source {
         get_default(self, key)
     }
 
-    /// Count the number of key-value pairs that can be visited.
+    /// Count the number of attributes that can be visited.
     ///
     /// # Implementation notes
     ///
-    /// A source that knows the number of key-value pairs upfront may provide a more
+    /// A source that knows the number of attributes upfront may provide a more
     /// efficient implementation.
     ///
-    /// A subsequent call to `visit` should yield the same number of key-value pairs
+    /// A subsequent call to `visit` should yield the same number of attributes
     /// to the visitor, unless that visitor fails part way through.
     fn count(&self) -> usize {
         count_default(self)

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -21,7 +21,7 @@ use std::fmt;
 ///
 /// ```
 /// # fn main() -> Result<(), log::kv::Error> {
-/// use log::kv::{self, Source, Key, Value, source::VisitSource};
+/// use log::kv::{self, Source, Key, Value, VisitSource};
 ///
 /// // A `VisitSource` that prints all key-values
 /// // VisitSources are fed the key-value pairs of each key-values

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -458,6 +458,10 @@ mod std_support {
     }
 }
 
+// NOTE: Deprecated; but aliases can't carry this attribute
+#[cfg(feature = "kv_unstable")]
+pub use VisitSource as Visitor;
+
 #[cfg(test)]
 mod tests {
     use crate::kv::value;

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -1,5 +1,5 @@
 //! Sources for key-values.
-//! 
+//!
 //! This module defines the [`Source`] type and supporting APIs for
 //! working with collections of key-values.
 
@@ -11,7 +11,7 @@ use std::fmt;
 /// The source may be a single pair, a set of pairs, or a filter over a set of pairs.
 /// Use the [`Visitor`](trait.Visitor.html) trait to inspect the structured data
 /// in a source.
-/// 
+///
 /// A source is like an iterator over its key-values, except with a push-based API
 /// instead of a pull-based one.
 ///
@@ -22,19 +22,19 @@ use std::fmt;
 /// ```
 /// # fn main() -> Result<(), log::kv::Error> {
 /// use log::kv::{self, Source, Key, Value, source::Visitor};
-/// 
+///
 /// // A `Visitor` that prints all key-values
 /// // Visitors are fed the key-value pairs of each key-values
 /// struct Printer;
-/// 
+///
 /// impl<'kvs> Visitor<'kvs> for Printer {
 ///     fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), kv::Error> {
 ///         println!("{key}: {value}");
-/// 
+///
 ///         Ok(())
 ///     }
 /// }
-/// 
+///
 /// // A source with 3 key-values
 /// // Common collection types implement the `Source` trait
 /// let source = &[
@@ -42,7 +42,7 @@ use std::fmt;
 ///     ("b", 2),
 ///     ("c", 3),
 /// ];
-/// 
+///
 /// // Pass an instance of the `Visitor` to a `Source` to visit it
 /// source.visit(&mut Printer)?;
 /// # Ok(())

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -1,4 +1,7 @@
 //! Sources for user-defined attributes.
+//! 
+//! This module defines the [`Source`] type and supporting APIs for
+//! working with collections of attributes.
 
 use crate::kv::{Error, Key, ToKey, ToValue, Value};
 use std::fmt;

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -1118,7 +1118,7 @@ impl<'v> Value<'v> {
 
 // NOTE: Deprecated; but aliases can't carry this attribute
 #[cfg(feature = "kv_unstable")]
-pub use VisitValue as Visitor;
+pub use VisitValue as Visit;
 
 /// Get a value from a type implementing `std::fmt::Debug`.
 #[cfg(feature = "kv_unstable")]

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -1,5 +1,5 @@
 //! Structured values.
-//! 
+//!
 //! This module defines the [`Value`] type and supporting APIs for
 //! capturing and serializing them.
 
@@ -90,9 +90,9 @@ impl<'v> ToValue for Value<'v> {
 /// For more complex types one of the following traits can be used:
 ///  * [`sval::Value`], requires the `kv_unstable_sval` feature.
 ///  * [`serde::Serialize`], requires the `kv_unstable_serde` feature.
-/// 
+///
 /// You don't need a [`Visit`] to serialize values.
-/// 
+///
 /// A value can always be serialized using any supported framework, regardless
 /// of how it was captured. If, for example, a value was captured using its
 /// `Display` implementation, it will serialize as a string. If it was captured
@@ -622,39 +622,57 @@ pub(in crate::kv) mod inner {
             }
 
             fn visit_u64(&mut self, value: u64) -> Result<(), Error> {
-                self.0.visit_u64(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_u64(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_i64(&mut self, value: i64) -> Result<(), Error> {
-                self.0.visit_i64(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_i64(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_u128(&mut self, value: u128) -> Result<(), Error> {
-                self.0.visit_u128(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_u128(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_i128(&mut self, value: i128) -> Result<(), Error> {
-                self.0.visit_i128(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_i128(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_f64(&mut self, value: f64) -> Result<(), Error> {
-                self.0.visit_f64(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_f64(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_bool(&mut self, value: bool) -> Result<(), Error> {
-                self.0.visit_bool(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_bool(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_str(&mut self, value: &str) -> Result<(), Error> {
-                self.0.visit_str(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_str(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_borrowed_str(&mut self, value: &'v str) -> Result<(), Error> {
-                self.0.visit_borrowed_str(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_borrowed_str(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             fn visit_char(&mut self, value: char) -> Result<(), Error> {
-                self.0.visit_char(value).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_char(value)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             #[cfg(feature = "kv_unstable_std")]
@@ -662,7 +680,9 @@ pub(in crate::kv) mod inner {
                 &mut self,
                 err: &(dyn std::error::Error + 'static),
             ) -> Result<(), Error> {
-                self.0.visit_error(err).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_error(err)
+                    .map_err(crate::kv::Error::into_value)
             }
 
             #[cfg(feature = "kv_unstable_std")]
@@ -670,7 +690,9 @@ pub(in crate::kv) mod inner {
                 &mut self,
                 err: &'v (dyn std::error::Error + 'static),
             ) -> Result<(), Error> {
-                self.0.visit_borrowed_error(err).map_err(crate::kv::Error::into_value)
+                self.0
+                    .visit_borrowed_error(err)
+                    .map_err(crate::kv::Error::into_value)
             }
         }
 
@@ -873,7 +895,6 @@ pub(in crate::kv) mod inner {
         F64(f64),
         I64(i64),
         U64(u64),
-
     }
 
     #[derive(Debug)]

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -602,11 +602,6 @@ pub(in crate::kv) mod inner {
     #[cfg(test)]
     pub use value_bag::test::TestToken as Token;
 
-    #[cfg(test)]
-    pub fn to_test_token<'v>(inner: &Inner<'v>) -> Token {
-        inner.to_test_token()
-    }
-
     pub fn visit<'v>(
         inner: &Inner<'v>,
         visitor: impl VisitValue<'v>,

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -857,10 +857,24 @@ pub(in crate::kv) mod inner {
         pub fn to_borrowed_str(&self) -> Option<&'v str> {
             todo!()
         }
+
+        #[cfg(test)]
+        pub fn to_test_token(&self) -> Token {
+            todo!()
+        }
     }
 
-    #[derive(Debug, PartialEq, Eq)]
-    pub enum Token {}
+    #[derive(Debug, PartialEq)]
+    pub enum Token<'v> {
+        None,
+        Bool(bool),
+        Char(char),
+        Str(&'v str),
+        F64(f64),
+        I64(i64),
+        U64(u64),
+
+    }
 
     #[derive(Debug)]
     pub struct Error {}

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -607,7 +607,10 @@ pub(in crate::kv) mod inner {
         inner.to_test_token()
     }
 
-    pub fn visit<'v>(inner: &Inner<'v>, visitor: impl VisitValue<'v>) -> Result<(), crate::kv::Error> {
+    pub fn visit<'v>(
+        inner: &Inner<'v>,
+        visitor: impl VisitValue<'v>,
+    ) -> Result<(), crate::kv::Error> {
         struct InnerVisitValue<V>(V);
 
         impl<'v, V> value_bag::visit::Visit<'v> for InnerVisitValue<V>

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -30,7 +30,7 @@ impl<'v> ToValue for Value<'v> {
     }
 }
 
-/// A value in a user-defined attribute.
+/// A value in a key-value.
 ///
 /// Values are an anonymous bag containing some structured datum.
 ///

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -1142,7 +1142,7 @@ macro_rules! as_display {
 
 /// Get a value from an error.
 #[cfg(feature = "kv_unstable_std")]
-#[deprecated(note = "use the `key:error = value` macro syntax instead")]
+#[deprecated(note = "use the `key:err = value` macro syntax instead")]
 #[macro_export]
 macro_rules! as_error {
     ($capture:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1760,13 +1760,13 @@ mod tests {
     #[cfg(feature = "kv_unstable")]
     fn test_record_key_values_builder() {
         use super::Record;
-        use crate::kv::{self, Visitor};
+        use crate::kv::{self, VisitSource};
 
-        struct TestVisitor {
+        struct TestVisitSource {
             seen_pairs: usize,
         }
 
-        impl<'kvs> Visitor<'kvs> for TestVisitor {
+        impl<'kvs> VisitSource<'kvs> for TestVisitSource {
             fn visit_pair(
                 &mut self,
                 _: kv::Key<'kvs>,
@@ -1780,7 +1780,7 @@ mod tests {
         let kvs: &[(&str, i32)] = &[("a", 1), ("b", 2)];
         let record_test = Record::builder().key_values(&kvs).build();
 
-        let mut visitor = TestVisitor { seen_pairs: 0 };
+        let mut visitor = TestVisitSource { seen_pairs: 0 };
 
         record_test.key_values().visit(&mut visitor).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //!
 //! ## Structured logging
 //!
-//! If you enable the `kv_unstable` feature you can associate structured values
+//! If you enable the `kv` feature you can associate structured values
 //! with your log records. If we take the example from before, we can include
 //! some additional context besides what's in the formatted message:
 //!
@@ -97,7 +97,7 @@
 //! # #[derive(Debug, Serialize)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
 //! # fn find_a_razor() -> Result<u32, std::io::Error> { Ok(1) }
-//! # #[cfg(feature = "kv_unstable_serde")]
+//! # #[cfg(feature = "kv_serde")]
 //! # fn main() {
 //! use log::{info, warn};
 //!
@@ -118,7 +118,7 @@
 //!     }
 //! }
 //! # }
-//! # #[cfg(not(feature = "kv_unstable_serde"))]
+//! # #[cfg(not(feature = "kv_serde"))]
 //! # fn main() {}
 //! ```
 //!
@@ -355,7 +355,7 @@ use std::{cmp, fmt, mem};
 mod macros;
 mod serde;
 
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 pub mod kv;
 
 #[cfg(target_has_atomic = "ptr")]
@@ -723,7 +723,7 @@ pub struct Record<'a> {
     module_path: Option<MaybeStaticStr<'a>>,
     file: Option<MaybeStaticStr<'a>>,
     line: Option<u32>,
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     key_values: KeyValues<'a>,
 }
 
@@ -731,11 +731,11 @@ pub struct Record<'a> {
 // `#[derive(Debug)]` on `Record`. It also
 // provides a useful `Debug` implementation for
 // the underlying `Source`.
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 #[derive(Clone)]
 struct KeyValues<'a>(&'a dyn kv::Source);
 
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 impl<'a> fmt::Debug for KeyValues<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut visitor = f.debug_map();
@@ -812,14 +812,14 @@ impl<'a> Record<'a> {
     }
 
     /// The structured key-value pairs associated with the message.
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     #[inline]
     pub fn key_values(&self) -> &dyn kv::Source {
         self.key_values.0
     }
 
     /// Create a new [`RecordBuilder`](struct.RecordBuilder.html) based on this record.
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     #[inline]
     pub fn to_builder(&self) -> RecordBuilder {
         RecordBuilder {
@@ -904,7 +904,7 @@ impl<'a> RecordBuilder<'a> {
                 module_path: None,
                 file: None,
                 line: None,
-                #[cfg(feature = "kv_unstable")]
+                #[cfg(feature = "kv")]
                 key_values: KeyValues(&None::<(kv::Key, kv::Value)>),
             },
         }
@@ -974,7 +974,7 @@ impl<'a> RecordBuilder<'a> {
     }
 
     /// Set [`key_values`](struct.Record.html#method.key_values)
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     #[inline]
     pub fn key_values(&mut self, kvs: &'a dyn kv::Source) -> &mut RecordBuilder<'a> {
         self.record.key_values = KeyValues(kvs);
@@ -1757,7 +1757,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     fn test_record_key_values_builder() {
         use super::Record;
         use crate::kv::{self, VisitSource};
@@ -1788,7 +1788,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     fn test_record_key_values_get_coerce() {
         use super::Record;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@
 //! # #[cfg(not(feature = "kv_unstable_serde"))]
 //! # fn main() {}
 //! ```
+//! 
+//! See the [`kv`] module documentation for more details.
 //!
 //! # Available logging implementations
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@
 //!                 break;
 //!             }
 //!             Err(err) => {
-//!                 warn!(err:error = err; "Unable to locate a razor, retrying");
+//!                 warn!(err:err; "Unable to locate a razor, retrying");
 //!             }
 //!         }
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,17 +102,17 @@
 //! use log::{info, warn};
 //!
 //! pub fn shave_the_yak(yak: &mut Yak) {
-//!     info!(target: "yak_events", yak:serde = yak; "Commencing yak shaving");
+//!     info!(target: "yak_events", yak:serde; "Commencing yak shaving");
 //!
 //!     loop {
 //!         match find_a_razor() {
 //!             Ok(razor) => {
-//!                 info!(razor = razor; "Razor located");
+//!                 info!(razor; "Razor located");
 //!                 yak.shave(razor);
 //!                 break;
 //!             }
-//!             Err(err) => {
-//!                 warn!(err:err; "Unable to locate a razor, retrying");
+//!             Err(e) => {
+//!                 warn!(e:err; "Unable to locate a razor, retrying");
 //!             }
 //!         }
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,10 @@
 //! # fn find_a_razor() -> Result<u32, std::io::Error> { Ok(1) }
 //! # #[cfg(feature = "kv_unstable_serde")]
 //! # fn main() {
-//! use log::{info, warn, as_serde, as_error};
+//! use log::{info, warn};
 //!
 //! pub fn shave_the_yak(yak: &mut Yak) {
-//!     info!(target: "yak_events", yak = as_serde!(yak); "Commencing yak shaving");
+//!     info!(target: "yak_events", yak:serde = yak; "Commencing yak shaving");
 //!
 //!     loop {
 //!         match find_a_razor() {
@@ -112,7 +112,7 @@
 //!                 break;
 //!             }
 //!             Err(err) => {
-//!                 warn!(err = as_error!(err); "Unable to locate a razor, retrying");
+//!                 warn!(err:error = err; "Unable to locate a razor, retrying");
 //!             }
 //!         }
 //!     }
@@ -121,7 +121,7 @@
 //! # #[cfg(not(feature = "kv_unstable_serde"))]
 //! # fn main() {}
 //! ```
-//! 
+//!
 //! See the [`kv`] module documentation for more details.
 //!
 //! # Available logging implementations

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -288,7 +288,7 @@ macro_rules! __log_value {
         $crate::__private_api::capture_display(&&$args)
     };
     //Error
-    (($args:expr):error) => {
+    (($args:expr):err) => {
         $crate::__log_value_error!($args)
     };
     // sval::Value

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@
 /// ```
 #[macro_export]
 macro_rules! log {
-    // log!(target: "my_target", Level::Info, key1 = 42, key2 = true; "a {} event", "log");
+    // log!(target: "my_target", Level::Info, key1:? = 42, key2 = true; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($key:tt $(:$capture:tt)? = $value:expr),+; $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
@@ -225,6 +225,9 @@ macro_rules! log_enabled {
         $crate::log_enabled!(target: $crate::__private_api::module_path!(), $lvl)
     };
 }
+
+// These macros use a pattern of #[cfg]s to produce nicer error
+// messages when log features aren't available
 
 #[doc(hidden)]
 #[macro_export]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -312,17 +312,6 @@ macro_rules! __log_value {
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(feature = "kv_std"))]
-macro_rules! __log_value_error {
-    ($args:expr) => {
-        compile_error!(
-            "capturing values as `std::error::Error` requites the `kv_std` feature of `log`"
-        )
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
 #[cfg(feature = "kv_sval")]
 macro_rules! __log_value_sval {
     ($args:expr) => {
@@ -365,5 +354,16 @@ macro_rules! __log_value_serde {
 macro_rules! __log_value_error {
     ($args:expr) => {
         $crate::__private_api::capture_error(&$args)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "kv_std"))]
+macro_rules! __log_value_error {
+    ($args:expr) => {
+        compile_error!(
+            "capturing values as `std::error::Error` requites the `kv_std` feature of `log`"
+        )
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -231,7 +231,7 @@ macro_rules! log_enabled {
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 macro_rules! __log_key {
     // key1 = 42
     ($($args:ident)*) => {
@@ -245,16 +245,16 @@ macro_rules! __log_key {
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(feature = "kv_unstable"))]
+#[cfg(not(feature = "kv"))]
 macro_rules! __log_key {
     ($($args:tt)*) => {
-        compile_error!("key value support requires the `kv_unstable` feature of `log`")
+        compile_error!("key value support requires the `kv` feature of `log`")
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 macro_rules! __log_value {
     // Default
     (($args:expr)) => {
@@ -294,25 +294,27 @@ macro_rules! __log_value {
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(feature = "kv_unstable"))]
+#[cfg(not(feature = "kv"))]
 macro_rules! __log_value {
     ($($args:tt)*) => {
-        compile_error!("key value support requires the `kv_unstable` feature of `log`")
+        compile_error!("key value support requires the `kv` feature of `log`")
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(feature = "kv_unstable_std"))]
+#[cfg(not(feature = "kv_std"))]
 macro_rules! __log_value_error {
     ($args:expr) => {
-        compile_error!("capturing values as `std::error::Error` requites the `kv_unstable_std` feature of `log`")
-    }
+        compile_error!(
+            "capturing values as `std::error::Error` requites the `kv_std` feature of `log`"
+        )
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(feature = "kv_unstable_sval")]
+#[cfg(feature = "kv_sval")]
 macro_rules! __log_value_sval {
     ($args:expr) => {
         $crate::__private_api::capture_sval(&&$args)
@@ -321,18 +323,16 @@ macro_rules! __log_value_sval {
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(feature = "kv_unstable_sval"))]
+#[cfg(not(feature = "kv_sval"))]
 macro_rules! __log_value_sval {
     ($args:expr) => {
-        compile_error!(
-            "capturing values as `sval::Value` requites the `kv_unstable_sval` feature of `log`"
-        )
+        compile_error!("capturing values as `sval::Value` requites the `kv_sval` feature of `log`")
     };
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(feature = "kv_unstable_serde")]
+#[cfg(feature = "kv_serde")]
 macro_rules! __log_value_serde {
     ($args:expr) => {
         $crate::__private_api::capture_serde(&&$args)
@@ -341,16 +341,18 @@ macro_rules! __log_value_serde {
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(not(feature = "kv_unstable_serde"))]
+#[cfg(not(feature = "kv_serde"))]
 macro_rules! __log_value_serde {
     ($args:expr) => {
-        compile_error!("capturing values as `serde::Serialize` requites the `kv_unstable_serde` feature of `log`")
-    }
+        compile_error!(
+            "capturing values as `serde::Serialize` requites the `kv_serde` feature of `log`"
+        )
+    };
 }
 
 #[doc(hidden)]
 #[macro_export]
-#[cfg(feature = "kv_unstable_std")]
+#[cfg(feature = "kv_std")]
 macro_rules! __log_value_error {
     ($args:expr) => {
         $crate::__private_api::capture_error(&$args)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,10 +7,10 @@ build = "src/build.rs"
 
 [features]
 std = ["log/std"]
-kv_unstable = ["log/kv_unstable"]
-kv_unstable_std = ["log/kv_unstable_std"]
-kv_unstable_sval = ["log/kv_unstable_sval"]
-kv_unstable_serde = ["log/kv_unstable_serde"]
+kv = ["log/kv"]
+kv_std = ["log/kv_std"]
+kv_sval = ["log/kv_sval"]
+kv_serde = ["log/kv_serde"]
 
 [dependencies.log]
 path = ".."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,6 +7,10 @@ build = "src/build.rs"
 
 [features]
 std = ["log/std"]
+kv_unstable = ["log/kv_unstable"]
+kv_unstable_std = ["log/kv_unstable_std"]
+kv_unstable_sval = ["log/kv_unstable_sval"]
+kv_unstable_serde = ["log/kv_unstable_serde"]
 
 [dependencies.log]
 path = ".."

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -167,6 +167,15 @@ fn kv_named_args() {
 
 #[test]
 #[cfg(feature = "kv")]
+fn kv_ident() {
+    let cat_1 = "chashu";
+    let cat_2 = "nori";
+
+    all_log_macros!(cat_1, cat_2:%, cat_count = 2; "hello {world}", world = "world");
+}
+
+#[test]
+#[cfg(feature = "kv")]
 fn kv_expr_context() {
     match "chashu" {
         cat_1 => {
@@ -274,7 +283,7 @@ fn kv_display() {
 #[cfg(feature = "kv_std")]
 fn kv_error() {
     all_log_macros!(
-        a:error = std::io::Error::new(std::io::ErrorKind::Other, "an error");
+        a:err = std::io::Error::new(std::io::ErrorKind::Other, "an error");
         "hello world"
     );
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -250,6 +250,53 @@ fn kv_common_value_types() {
     );
 }
 
+#[test]
+#[cfg(feature = "kv_unstable")]
+fn kv_debug() {
+    all_log_macros!(
+        a:? = 42,
+        b:debug = 42;
+        "hello world"
+    );
+}
+
+#[test]
+#[cfg(feature = "kv_unstable")]
+fn kv_display() {
+    all_log_macros!(
+        a:% = 42,
+        b:display = 42;
+        "hello world"
+    );
+}
+
+#[test]
+#[cfg(feature = "kv_unstable_std")]
+fn kv_error() {
+    all_log_macros!(
+        a:error = std::io::Error::new(std::io::ErrorKind::Other, "an error");
+        "hello world"
+    );
+}
+
+#[test]
+#[cfg(feature = "kv_unstable_sval")]
+fn kv_sval() {
+    all_log_macros!(
+        a:sval = 42;
+        "hello world"
+    );
+}
+
+#[test]
+#[cfg(feature = "kv_unstable_serde")]
+fn kv_serde() {
+    all_log_macros!(
+        a:serde = 42;
+        "hello world"
+    );
+}
+
 /// Some and None (from Option) are used in the macros.
 #[derive(Debug)]
 enum Type {

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -107,7 +107,7 @@ fn expr() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_no_args() {
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
@@ -121,7 +121,7 @@ fn kv_no_args() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_expr_args() {
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
@@ -136,7 +136,7 @@ fn kv_expr_args() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_anonymous_args() {
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
@@ -151,7 +151,7 @@ fn kv_anonymous_args() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_named_args() {
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
@@ -166,7 +166,7 @@ fn kv_named_args() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_expr_context() {
     match "chashu" {
         cat_1 => {
@@ -196,14 +196,14 @@ fn implicit_named_args() {
     all_log_macros!(target: "my_target", "hello {world}");
     all_log_macros!(target: "my_target", "hello {world}",);
 
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     all_log_macros!(target = "my_target"; "hello {world}");
-    #[cfg(feature = "kv_unstable")]
+    #[cfg(feature = "kv")]
     all_log_macros!(target = "my_target"; "hello {world}",);
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_implicit_named_args() {
     let world = "world";
 
@@ -219,7 +219,7 @@ fn kv_implicit_named_args() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_string_keys() {
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, "also dogs" = "Fílos", "key/that-can't/be/an/ident" = "hi"; "hello {world}", world = "world");
@@ -229,7 +229,7 @@ fn kv_string_keys() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_common_value_types() {
     all_log_macros!(
         u8 = 42u8,
@@ -251,7 +251,7 @@ fn kv_common_value_types() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_debug() {
     all_log_macros!(
         a:? = 42,
@@ -261,7 +261,7 @@ fn kv_debug() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable")]
+#[cfg(feature = "kv")]
 fn kv_display() {
     all_log_macros!(
         a:% = 42,
@@ -271,7 +271,7 @@ fn kv_display() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable_std")]
+#[cfg(feature = "kv_std")]
 fn kv_error() {
     all_log_macros!(
         a:error = std::io::Error::new(std::io::ErrorKind::Other, "an error");
@@ -280,7 +280,7 @@ fn kv_error() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable_sval")]
+#[cfg(feature = "kv_sval")]
 fn kv_sval() {
     all_log_macros!(
         a:sval = 42;
@@ -289,7 +289,7 @@ fn kv_sval() {
 }
 
 #[test]
-#[cfg(feature = "kv_unstable_serde")]
+#[cfg(feature = "kv_serde")]
 fn kv_serde() {
     all_log_macros!(
         a:serde = 42;


### PR DESCRIPTION
Closes #149 
Closes #328 
Closes #357 
Closes #436 
Closes #584 

Based on the review in #584

The plan is to:

- [x] Deprecate `Value::capture_*` and `Value::downcast_*` methods. All deprecated APIs are gated under the old `kv_unstable` features and will be removed once we remove those old unstable features.
- [x] Fill in the documentation for structured logging support so people can actually use it.
- [x] Add some macro syntax for capturing attributes as debug or display instead of the default `ToValue` (`key:? = value`).
- [x] Only pull in `value-bag` as a dependency if either `serde` or `sval` is also needed. In cases where you just want basic structured logging, we should do it in a dependency-free way. This will just mean adding a simple `ValueInner` enum.

I'll cc once this is ready for review, to save a bit of notification noise.

Once this PR is complete, we should be able to stabilize structured logging support in the `log` crate.