### PR TITLE
Prepare for 0.4.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,36 @@
 # Change Log
 
 ## [Unreleased]
-* Migrate to 2021 edition and minor cleanups by @nyurik in https://github.com/rust-lang/log/pull/580
-* Use inline format args by @nyurik in https://github.com/rust-lang/log/pull/577
+
+## [0.4.21] - 2024-02-27
+
+## What's Changed
+* Minor clippy nits by @nyurik in https://github.com/rust-lang/log/pull/578
+* Simplify Display impl by @nyurik in https://github.com/rust-lang/log/pull/579
+* Set all crates to 2021 edition by @nyurik in https://github.com/rust-lang/log/pull/580
+* Various changes based on review by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/583
+* Fix typo in file_static() method doc by @dimo414 in https://github.com/rust-lang/log/pull/590
+* Specialize empty key value pairs by @EFanZh in https://github.com/rust-lang/log/pull/576
+* Fix incorrect lifetime in Value::to_str() by @peterjoel in https://github.com/rust-lang/log/pull/587
+* Remove some API of the key-value feature by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/585
+* Add logcontrol-log and log-reload by @swsnr in https://github.com/rust-lang/log/pull/595
+* Add Serialization section to kv::Value docs by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/593
+* Rename Value::to_str to to_cow_str by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/592
+* Clarify documentation and simplify initialization of `STATIC_MAX_LEVEL` by @ptosi in https://github.com/rust-lang/log/pull/594
+* Update docs to 2021 edition, test by @nyurik in https://github.com/rust-lang/log/pull/577
+* Add "alterable_logger" link to README.md by @brummer-simon in https://github.com/rust-lang/log/pull/589
+* Normalize line ending by @EFanZh in https://github.com/rust-lang/log/pull/602
+* Remove `ok_or` in favor of `Option::ok_or` by @AngelicosPhosphoros in https://github.com/rust-lang/log/pull/607
+* Use `Acquire` ordering for initialization check by @AngelicosPhosphoros in https://github.com/rust-lang/log/pull/610
+* Get structured logging API ready for stabilization by @KodrAus in https://github.com/rust-lang/log/pull/613
+
+## New Contributors
+* @nyurik made their first contribution in https://github.com/rust-lang/log/pull/578
+* @dimo414 made their first contribution in https://github.com/rust-lang/log/pull/590
+* @peterjoel made their first contribution in https://github.com/rust-lang/log/pull/587
+* @ptosi made their first contribution in https://github.com/rust-lang/log/pull/594
+* @brummer-simon made their first contribution in https://github.com/rust-lang/log/pull/589
+* @AngelicosPhosphoros made their first contribution in https://github.com/rust-lang/log/pull/607
 
 ## [0.4.20] - 2023-07-11
 
@@ -250,7 +278,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.18...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.21...HEAD
+[0.4.21]: https://github.com/rust-lang/log/compare/0.4.20...0.4.21
 [0.4.20]: https://github.com/rust-lang-nursery/log/compare/0.4.19...0.4.20
 [0.4.19]: https://github.com/rust-lang-nursery/log/compare/0.4.18...0.4.19
 [0.4.18]: https://github.com/rust-lang-nursery/log/compare/0.4.17...0.4.18

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.20" # remember to update html_root_url
+version = "0.4.21" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.20"
+    html_root_url = "https://docs.rs/log/0.4.21"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
cc @Thomasdezeeuw @JohnTitor This release stabilizes our structured logging API.

Closes #616 

## What's Changed
* Minor clippy nits by @nyurik in https://github.com/rust-lang/log/pull/578
* Simplify Display impl by @nyurik in https://github.com/rust-lang/log/pull/579
* Set all crates to 2021 edition by @nyurik in https://github.com/rust-lang/log/pull/580
* Various changes based on review by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/583
* Fix typo in file_static() method doc by @dimo414 in https://github.com/rust-lang/log/pull/590
* Specialize empty key value pairs by @EFanZh in https://github.com/rust-lang/log/pull/576
* Fix incorrect lifetime in Value::to_str() by @peterjoel in https://github.com/rust-lang/log/pull/587
* Remove some API of the key-value feature by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/585
* Add logcontrol-log and log-reload by @swsnr in https://github.com/rust-lang/log/pull/595
* Add Serialization section to kv::Value docs by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/593
* Rename Value::to_str to to_cow_str by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/592
* Clarify documentation and simplify initialization of `STATIC_MAX_LEVEL` by @ptosi in https://github.com/rust-lang/log/pull/594
* Update docs to 2021 edition, test by @nyurik in https://github.com/rust-lang/log/pull/577
* Add "alterable_logger" link to README.md by @brummer-simon in https://github.com/rust-lang/log/pull/589
* Normalize line ending by @EFanZh in https://github.com/rust-lang/log/pull/602
* Remove `ok_or` in favor of `Option::ok_or` by @AngelicosPhosphoros in https://github.com/rust-lang/log/pull/607
* Use `Acquire` ordering for initialization check by @AngelicosPhosphoros in https://github.com/rust-lang/log/pull/610
* Get structured logging API ready for stabilization by @KodrAus in https://github.com/rust-lang/log/pull/613