### PR TITLE
CI should detect when breaking changes are introduced

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,14 @@ jobs:
     - run: cargo clippy --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo clippy --verbose --manifest-path tests/Cargo.toml
 
+  semver:
+    name: Semver check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Check semver in case we must bump the version due to breaking changes
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+
   doc:
     name: Check Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Note that this uses a separate semver job - which may be an overkill - perhaps it should be added to the clippy job?  I wouldn't want it to compile so many times in different VMs unless needed.

See https://github.com/obi1kenobi/cargo-semver-checks?tab=readme-ov-file#quick-start