### PR TITLE
Add links to `colog` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There are many available implementations to choose from, here are some options:
 
 * Simple minimal loggers:
     * [`env_logger`](https://docs.rs/env_logger/*/env_logger/)
+    * [`colog`](https://docs.rs/colog/*/colog/)
     * [`simple_logger`](https://docs.rs/simple_logger/*/simple_logger/)
     * [`simplelog`](https://docs.rs/simplelog/*/simplelog/)
     * [`pretty_env_logger`](https://docs.rs/pretty_env_logger/*/pretty_env_logger/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@
 //!
 //! * Simple minimal loggers:
 //!     * [env_logger]
+//!     * [colog]
 //!     * [simple_logger]
 //!     * [simplelog]
 //!     * [pretty_env_logger]
@@ -310,6 +311,7 @@
 //! [`try_set_logger_raw`]: fn.try_set_logger_raw.html
 //! [`shutdown_logger_raw`]: fn.shutdown_logger_raw.html
 //! [env_logger]: https://docs.rs/env_logger/*/env_logger/
+//! [colog]: https://docs.rs/colog/*/colog/
 //! [simple_logger]: https://github.com/borntyping/rust-simple_logger
 //! [simplelog]: https://github.com/drakulix/simplelog.rs
 //! [pretty_env_logger]: https://docs.rs/pretty_env_logger/*/pretty_env_logger/


### PR DESCRIPTION
Hi 👋

I'm the maintained or the [colog](https://crates.io/crates/colog) crate.

My crate provides a quick way to set up colored logging with a (subjectively) good and clean look.

I've just released version 1.3, which in my opinion is hugely improved.

Everything is now extensively documented, and there are 7 included examples on using the crate. The crate has been around for 8 years, so it's not exactly abandonware ;-)

I would greatly appreciate it, if you would include it in the list of possible logging crates in your documentation (see this PR)