### PR TITLE
Clarify the actual set of functions that can race in _racy variants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1243,13 +1243,13 @@ pub fn set_max_level(level: LevelFilter) {
 ///
 /// # Safety
 ///
-/// This function is only safe to call when no other level setting function is
-/// called while this function still executes.
+/// This function is only safe to call when it cannot race with any other
+/// calls to `set_max_level` or `set_max_level_racy`.
 ///
 /// This can be upheld by (for example) making sure that **there are no other
 /// threads**, and (on embedded) that **interrupts are disabled**.
 ///
-/// Is is safe to use all other logging functions while this function runs
+/// It is safe to use all other logging functions while this function runs
 /// (including all logging macros).
 ///
 /// [`set_max_level`]: fn.set_max_level.html
@@ -1403,8 +1403,8 @@ where
 ///
 /// # Safety
 ///
-/// This function is only safe to call when no other logger initialization
-/// function is called while this function still executes.
+/// This function is only safe to call when it cannot race with any other
+/// calls to `set_logger` or `set_logger_racy`.
 ///
 /// This can be upheld by (for example) making sure that **there are no other
 /// threads**, and (on embedded) that **interrupts are disabled**.


### PR DESCRIPTION
Includes #622

I noticed our docs for these functions could use a bit more direct wording around exactly what they could race with.