### PR TITLE
Replace deprecated std::sync::atomic::spin_loop_hint()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1384,9 +1384,7 @@ where
         }
         INITIALIZING => {
             while STATE.load(Ordering::SeqCst) == INITIALIZING {
-                // TODO: replace with `hint::spin_loop` once MSRV is 1.49.0.
-                #[allow(deprecated)]
-                std::sync::atomic::spin_loop_hint();
+                std::hint::spin_loop();
             }
             Err(SetLoggerError(()))
         }


### PR DESCRIPTION
I noticed that `log`'s MSRV is now 1.60.0+, which seems to indicate that the TODO that was waiting for MSRV 1.49.0 can now be fulfilled.