### PR TITLE
Loosen orderings for logger initialization

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 build = "src/build.rs"
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(lib_build)'] }
+
 [features]
 std = ["log/std"]
 kv = ["log/kv"]


### PR DESCRIPTION
This is a reworking of #520 using the same orderings. I think the main improvement was made in #610 so if we want to punt on this I think we reasonably can.