### PR TITLE
Use Location::caller() for file and line info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,10 +341,6 @@
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-// When compiled for the rustc compiler itself we want to make sure that this is
-// an unstable crate
-#![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
-#![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
 
 #[cfg(any(
     all(feature = "max_level_off", feature = "max_level_error"),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,8 +36,7 @@ macro_rules! log {
             $crate::__private_api::log::<&_>(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
-                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
-                $crate::__private_api::line!(),
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::loc()),
                 &[$(($crate::__log_key!($key), $crate::__log_value!($key $(:$capture)* = $($value)*))),+]
             );
         }
@@ -50,8 +49,7 @@ macro_rules! log {
             $crate::__private_api::log(
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
-                &($target, $crate::__private_api::module_path!(), $crate::__private_api::file!()),
-                $crate::__private_api::line!(),
+                &($target, $crate::__private_api::module_path!(), $crate::__private_api::loc()),
                 (),
             );
         }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 publish = false
 build = "src/build.rs"
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(lib_build)'] }
+
 [features]
 std = ["log/std"]
 kv = ["log/kv"]


### PR DESCRIPTION
Rework of #599. I've followed the suggestion in https://github.com/rust-lang/log/pull/599#issuecomment-2143472357 to pass a `panic::Location` to our non-inlined private log function in the hope it will avoid bloating callsites.