### PR TITLE
Add `spdlog-rs` link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ There are many available implementations to choose from, here are some options:
     * [`log4rs`](https://docs.rs/log4rs/*/log4rs/)
     * [`logforth`](https://docs.rs/logforth/*/logforth/)
     * [`fern`](https://docs.rs/fern/*/fern/)
+    * [`spdlog-rs`](https://docs.rs/spdlog-rs/*/spdlog/)
 * Adaptors for other facilities:
     * [`syslog`](https://docs.rs/syslog/*/syslog/)
     * [`systemd-journal-logger`](https://docs.rs/systemd-journal-logger/*/systemd_journal_logger/)


### PR DESCRIPTION
Hi, I would like to add a link to my personal project [`spdlog-rs`](https://github.com/SpriteOvO/spdlog-rs) to the README. It is inspired by the C++ logging library ``spdlog`` and is designed to provide performance benefits.

Based on [the benchmarks](https://github.com/SpriteOvO/spdlog-rs/blob/06aaa90ae9f646e2b7e8058700cd526583da05a7/spdlog/benches/README.md), it's probably the fastest logging crate yet. And it is also compatible with `log` crate.

I've been maintaining this project for 3 years and today I released its [v0.4.0](https://github.com/SpriteOvO/spdlog-rs/releases/tag/v0.4.0) version. I believe it is ready to be used by more users.