### PR TITLE
Implement conversions between Option<Level> and LevelFilter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,6 +635,21 @@ impl FromStr for LevelFilter {
     }
 }
 
+impl From<LevelFilter> for Option<Level> {
+    fn from(level: LevelFilter) -> Option<Level> {
+        level.to_level()
+    }
+}
+
+impl From<Option<Level>> for LevelFilter {
+    fn from(level: Option<Level>) -> LevelFilter {
+        match level {
+            Some(level) => level.to_level_filter(),
+            None => LevelFilter::Off,
+        }
+    }
+}
+
 impl fmt::Display for LevelFilter {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.pad(self.as_str())


### PR DESCRIPTION
This is nice to have when working with the `log` crate, as it allows
for more ergonomic conversions between the two types. Specifically, This
allows type bounds that require Into<LevelFilter> or Into<Option<Level>>
to be used. This in turn makes it possible to write more generic code
that can work with tracing and log crates interchangeably.

Specifically, this supports some ideas in
https://github.com/clap-rs/clap-verbosity-flag/issues/121
