### PR TITLE
Bind lifetimes of &str returned from Key by the lifetime of 'k rather than the lifetime of the Key struct

### DIFF
--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -45,7 +45,7 @@ impl<'k> Key<'k> {
     }
 
     /// Get a borrowed string from this key.
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'k str {
         self.key
     }
 }
@@ -57,7 +57,7 @@ impl<'k> fmt::Display for Key<'k> {
 }
 
 impl<'k> AsRef<str> for Key<'k> {
-    fn as_ref(&self) -> &str {
+    fn as_ref(&self) -> &'k str {
         self.as_str()
     }
 }

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -57,7 +57,7 @@ impl<'k> fmt::Display for Key<'k> {
 }
 
 impl<'k> AsRef<str> for Key<'k> {
-    fn as_ref(&self) -> &'k str {
+    fn as_ref(&self) -> &str {
         self.as_str()
     }
 }


### PR DESCRIPTION
This allows things inside a Visitor to persist these strings for the lifetime of 'k without having to copy them.