### PR TITLE
Add Ftail implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ There are many available implementations to choose from, here are some options:
     * [`std-logger`](https://docs.rs/std-logger/*/std_logger/)
     * [`structured-logger`](https://docs.rs/structured-logger/latest/structured_logger/)
     * [`clang_log`](https://docs.rs/clang_log/latest/clang_log)
+    * [`ftail`](https://docs.rs/ftail/latest/ftail/)
 * Complex configurable frameworks:
     * [`log4rs`](https://docs.rs/log4rs/*/log4rs/)
     * [`logforth`](https://docs.rs/logforth/*/logforth/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@
 //!     * [call_logger]
 //!     * [structured-logger]
 //!     * [clang_log]
+//!     * [ftail]
 //! * Complex configurable frameworks:
 //!     * [log4rs]
 //!     * [logforth]
@@ -336,6 +337,7 @@
 //! [log_err]: https://docs.rs/log_err/*/log_err/
 //! [log-reload]: https://docs.rs/log-reload/*/log_reload/
 //! [clang_log]: https://docs.rs/clang_log/latest/clang_log
+//! [ftail]: https://docs.rs/ftail/latest/ftail
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",


### PR DESCRIPTION
Adds [Ftail](https://crates.io/crates/ftail) to the list of 'simple minimal loggers'.

Ftail is a simple log implementation that allows logging to the console, a single file, a daily rotating file and to add your own custom option.

Thanks!