### PR TITLE
Relax feature flag for value's std_support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
     - run: cargo test --verbose --features kv
     - run: cargo test --verbose --features kv_sval
     - run: cargo test --verbose --features kv_serde
+    - run: cargo test --verbose --features kv,std
     - run: cargo test --verbose --features "kv kv_std kv_sval kv_serde"
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -3,7 +3,6 @@
 //! This module defines the [`Value`] type and supporting APIs for
 //! capturing and serializing them.
 
-use alloc::borrow::Cow;
 use std::fmt;
 
 pub use crate::kv::Error;
@@ -443,7 +442,7 @@ mod std_support {
 #[cfg(all(feature = "std", feature = "value-bag"))]
 impl<'v> Value<'v> {
     /// Try to convert this value into a string.
-    pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {
+    pub fn to_cow_str(&self) -> Option<std::borrow::Cow<'v, str>> {
         self.inner.to_str()
     }
 }
@@ -451,8 +450,8 @@ impl<'v> Value<'v> {
 #[cfg(all(feature = "std", not(feature = "value-bag")))]
 impl<'v> Value<'v> {
     /// Try to convert this value into a string.
-    pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {
-        self.inner.to_borrowed_str().map(Cow::Borrowed)
+    pub fn to_cow_str(&self) -> Option<std::borrow::Cow<'v, str>> {
+        self.inner.to_borrowed_str().map(std::borrow::Cow::Borrowed)
     }
 }
 

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -448,6 +448,14 @@ impl<'v> Value<'v> {
     }
 }
 
+#[cfg(all(feature = "std", not(feature = "value-bag")))]
+impl<'v> Value<'v> {
+    /// Try to convert this value into a string.
+    pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {
+        self.inner.to_borrowed_str().map(Cow::Borrowed)
+    }
+}
+
 /// A visitor for a [`Value`].
 ///
 /// Also see [`Value`'s documentation on seralization]. Value visitors are a simple alternative

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -385,7 +385,7 @@ impl<'v> Value<'v> {
     }
 }
 
-#[cfg(feature = "kv_std")]
+#[cfg(feature = "std")]
 mod std_support {
     use std::borrow::Cow;
     use std::rc::Rc;

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -3,6 +3,7 @@
 //! This module defines the [`Value`] type and supporting APIs for
 //! capturing and serializing them.
 
+use alloc::borrow::Cow;
 use std::fmt;
 
 pub use crate::kv::Error;
@@ -432,17 +433,18 @@ mod std_support {
         }
     }
 
-    impl<'v> Value<'v> {
-        /// Try to convert this value into a string.
-        pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {
-            self.inner.to_str()
-        }
-    }
-
     impl<'v> From<&'v String> for Value<'v> {
         fn from(v: &'v String) -> Self {
             Value::from(&**v)
         }
+    }
+}
+
+#[cfg(all(feature = "std", feature = "value-bag"))]
+impl<'v> Value<'v> {
+    /// Try to convert this value into a string.
+    pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {
+        self.inner.to_str()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,7 @@ compile_error!("multiple release_max_level_* features set");
 
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
+extern crate alloc;
 
 use std::cfg;
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,6 @@ compile_error!("multiple release_max_level_* features set");
 
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
-extern crate alloc;
 
 use std::cfg;
 #[cfg(feature = "std")]


### PR DESCRIPTION
This closes https://github.com/rust-lang/log/issues/654#issuecomment-2581445570.

While I agree @KodrAus's comment at https://github.com/rust-lang/log/issues/654#issuecomment-2581494083, this is not a generally breaking down kv_x to kv + x.

But that value's `std_support` can work with kv + std. `kv_std` introduces an extra feature of `value-bag/error`, which is only used for:

```rust
    pub fn to_borrowed_error(&self) -> Option<&(dyn std::error::Error + 'static)> {
        self.inner.to_borrowed_error()
    }
```

above.