### PR TITLE
Use cargo hack in CI to test all feature combinations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,8 @@ jobs:
       run: |
         rustup update ${{ matrix.rust }} --no-self-update
         rustup default ${{ matrix.rust }}
-    - run: cargo test --verbose
-    - run: cargo test --verbose --no-default-features
-    - run: cargo test --verbose --features std,serde,sval,sval_ref,value-bag,kv,kv_std,kv_sval,kv_serde
-    - run: cargo test --verbose --features serde
-    - run: cargo test --verbose --features std
-    - run: cargo test --verbose --features kv
-    - run: cargo test --verbose --features kv_sval
-    - run: cargo test --verbose --features kv_serde
-    - run: cargo test --verbose --features kv,std
-    - run: cargo test --verbose --features "kv kv_std kv_sval kv_serde"
+        cargo install cargo-hack
+    - run: cargo hack test --feature-powerset --lib --exclude-features max_level_off,max_level_error,max_level_warn,max_level_info,max_level_debug,max_level_trace,release_max_level_off,release_max_level_error,release_max_level_warn,release_max_level_info,release_max_level_debug,release_max_level_trace
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,11 @@ release_max_level_info  = []
 release_max_level_debug = []
 release_max_level_trace = []
 
-std = []
+std = ["value-bag?/error"]
 
 kv = []
 kv_sval = ["kv", "value-bag/sval", "sval", "sval_ref"]
-kv_std = ["std", "kv", "value-bag/error"]
+kv_std = ["std", "kv"]
 kv_serde = ["kv_std", "value-bag/serde", "serde"]
 
 # Deprecated: use `kv_*` instead


### PR DESCRIPTION
Closes #658 

Looks like a feature combination broke in `0.4.23`, so I've added [`cargo hack`](https://github.com/taiki-e/cargo-hack?tab=readme-ov-file#--feature-powerset) to our CI to make sure we test all possible combinations.