### PR TITLE
Revert loosening of kv cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ release_max_level_info  = []
 release_max_level_debug = []
 release_max_level_trace = []
 
-std = ["value-bag?/std"]
+std = []
 
 kv = []
 kv_sval = ["kv", "value-bag/sval", "sval", "sval_ref"]

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -385,7 +385,7 @@ impl<'v> Value<'v> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "kv_std")]
 mod std_support {
     use std::borrow::Cow;
     use std::rc::Rc;
@@ -432,26 +432,17 @@ mod std_support {
         }
     }
 
+    impl<'v> Value<'v> {
+        /// Try convert this value into a string.
+        pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {
+            self.inner.to_str()
+        }
+    }
+
     impl<'v> From<&'v String> for Value<'v> {
         fn from(v: &'v String) -> Self {
             Value::from(&**v)
         }
-    }
-}
-
-#[cfg(all(feature = "std", feature = "value-bag"))]
-impl<'v> Value<'v> {
-    /// Try to convert this value into a string.
-    pub fn to_cow_str(&self) -> Option<std::borrow::Cow<'v, str>> {
-        self.inner.to_str()
-    }
-}
-
-#[cfg(all(feature = "std", not(feature = "value-bag")))]
-impl<'v> Value<'v> {
-    /// Try to convert this value into a string.
-    pub fn to_cow_str(&self) -> Option<std::borrow::Cow<'v, str>> {
-        self.inner.to_borrowed_str().map(std::borrow::Cow::Borrowed)
     }
 }
 


### PR DESCRIPTION
Closes #661 

cc @Thomasdezeeuw @tisonkun

In #657 we moved some `kv_std` code into `kv` + `std`, but this unfortunately has hit a Cargo bug (see #661), which causes our `kv` dependencies to always end up in a dependents lockfile. Until the Cargo bug is fixed, or we find a different approach, I think we unfortunately need to revert this.