### PR TITLE
Prepare for 0.4.25 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.4.25] - 2025-01-14
+
+## What's Changed
+* Revert loosening of kv cargo features by @KodrAus in https://github.com/rust-lang/log/pull/662
+
+
+**Full Changelog**: https://github.com/rust-lang/log/compare/0.4.24...0.4.25
+
 ## [0.4.24] - 2025-01-11
 
 ## What's Changed
@@ -330,7 +338,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.24...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.25...HEAD
+[0.4.25]: https://github.com/rust-lang/log/compare/0.4.24...0.4.25
 [0.4.24]: https://github.com/rust-lang/log/compare/0.4.23...0.4.24
 [0.4.23]: https://github.com/rust-lang/log/compare/0.4.22...0.4.23
 [0.4.22]: https://github.com/rust-lang/log/compare/0.4.21...0.4.22

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.24" # remember to update html_root_url
+version = "0.4.25" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.24"
+    html_root_url = "https://docs.rs/log/0.4.25"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
## What's Changed
* Revert loosening of kv cargo features by @KodrAus in https://github.com/rust-lang/log/pull/662