### PR TITLE
Enable clippy support for format-like macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,6 +28,7 @@
 /// # }
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! log {
     // log!(target: "my_target", Level::Info, key1:? = 42, key2 = true; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($key:tt $(:$capture:tt)? $(= $value:expr)?),+; $($arg:tt)+) => ({
@@ -74,6 +75,7 @@ macro_rules! log {
 /// # }
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! error {
     // error!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // error!(target: "my_target", "a {} event", "log")
@@ -98,6 +100,7 @@ macro_rules! error {
 /// # }
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! warn {
     // warn!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // warn!(target: "my_target", "a {} event", "log")
@@ -124,6 +127,7 @@ macro_rules! warn {
 /// # }
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! info {
     // info!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // info!(target: "my_target", "a {} event", "log")
@@ -149,6 +153,7 @@ macro_rules! info {
 /// # }
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! debug {
     // debug!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // debug!(target: "my_target", "a {} event", "log")
@@ -176,6 +181,7 @@ macro_rules! debug {
 /// # }
 /// ```
 #[macro_export]
+#[clippy::format_args]
 macro_rules! trace {
     // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
     // trace!(target: "my_target", "a {} event", "log")


### PR DESCRIPTION
Add `#[clippy::format_args]` as described in [Clippy book](https://doc.rust-lang.org/nightly/clippy/attribs.html#clippyformat_args)

This is a new feature in v1.85