### PR TITLE
Add `spdlog-rs` link to crate doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@
 //!     * [log4rs]
 //!     * [logforth]
 //!     * [fern]
+//!     * [spdlog-rs]
 //! * Adaptors for other facilities:
 //!     * [syslog]
 //!     * [slog-stdlog]
@@ -326,6 +327,7 @@
 //! [log4rs]: https://docs.rs/log4rs/*/log4rs/
 //! [logforth]: https://docs.rs/logforth/*/logforth/
 //! [fern]: https://docs.rs/fern/*/fern/
+//! [spdlog-rs]: https://docs.rs/spdlog-rs/*/spdlog/
 //! [systemd-journal-logger]: https://docs.rs/systemd-journal-logger/*/systemd_journal_logger/
 //! [android_log]: https://docs.rs/android_log/*/android_log/
 //! [win_dbg_logger]: https://docs.rs/win_dbg_logger/*/win_dbg_logger/


### PR DESCRIPTION
PR #639 only added the link to README, but forgot to add it in the crate doc.

I apologize for opening another new PR for this.