### PR TITLE
Prepare for 0.4.26 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.4.26] - 2025-02-18
+
+## What's Changed
+* Derive `Clone` for `kv::Value` by @SpriteOvO in https://github.com/rust-lang/log/pull/668
+* Add `spdlog-rs` link to crate doc by @SpriteOvO in https://github.com/rust-lang/log/pull/669
+
+
+**Full Changelog**: https://github.com/rust-lang/log/compare/0.4.25...0.4.26
+
 ## [0.4.25] - 2025-01-14
 
 ## What's Changed
@@ -338,7 +347,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.25...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.26...HEAD
+[0.4.26]: https://github.com/rust-lang/log/compare/0.4.25...0.4.26
 [0.4.25]: https://github.com/rust-lang/log/compare/0.4.24...0.4.25
 [0.4.24]: https://github.com/rust-lang/log/compare/0.4.23...0.4.24
 [0.4.23]: https://github.com/rust-lang/log/compare/0.4.22...0.4.23

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.25" # remember to update html_root_url
+version = "0.4.26" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.25"
+    html_root_url = "https://docs.rs/log/0.4.26"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
## What's Changed
* Derive `Clone` for `kv::Value` by @SpriteOvO in https://github.com/rust-lang/log/pull/668
* Add `spdlog-rs` link to crate doc by @SpriteOvO in https://github.com/rust-lang/log/pull/669