### PR TITLE
Pass global logger by value, supplied logger by ref

### DIFF
--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -85,7 +85,7 @@ fn log_impl<L: Log>(
 }
 
 pub fn log<'a, K, L>(
-    logger: &L,
+    logger: L,
     args: Arguments,
     level: Level,
     target_module_path_and_loc: &(&str, &'static str, &'static Location),

--- a/src/__private_api.rs
+++ b/src/__private_api.rs
@@ -35,11 +35,7 @@ impl<'a> KVs<'a> for () {
 // Log implementation.
 
 /// The global logger proxy.
-///
-/// This zero-sized type implements the [`Log`] trait by forwarding calls
-/// to the logger registered with the `set_boxed_logger` or `set_logger`
-/// methods if there is one, or a nop logger as default.
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Debug)]
 pub struct GlobalLogger;
 
 impl Log for GlobalLogger {
@@ -56,6 +52,7 @@ impl Log for GlobalLogger {
     }
 }
 
+// Split from `log` to reduce generics and code size
 fn log_impl<L: Log>(
     logger: L,
     args: Arguments,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -405,12 +405,12 @@ macro_rules! log_enabled {
 #[macro_export]
 macro_rules! __log_enabled {
     // log_enabled!(logger: my_logger, target: "my_target", Level::Info)
-    (logger: $logger:expr, target: $target:expr, $lvl:expr) => ({
+    (logger: $logger:expr, target: $target:expr, $lvl:expr) => {{
         let lvl = $lvl;
         lvl <= $crate::STATIC_MAX_LEVEL
             && lvl <= $crate::max_level()
             && $crate::__private_api::enabled($logger, lvl, $target)
-    });
+    }};
 }
 
 // Determine the logger to use, and whether to take it by-value or by reference
@@ -418,13 +418,13 @@ macro_rules! __log_enabled {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __log_logger {
-    (__log_global_logger) => ({
+    (__log_global_logger) => {{
         $crate::__private_api::GlobalLogger
-    });
+    }};
 
-    ($logger:expr) => ({
+    ($logger:expr) => {{
         &($logger)
-    });
+    }};
 }
 
 // These macros use a pattern of #[cfg]s to produce nicer error

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -58,11 +58,17 @@
 ///
 /// let my_logger = MyLogger {};
 /// log!(
-///     logger: &my_logger,
+///     logger: my_logger,
 ///     Level::Error,
 ///     "Received errors: {}, {}",
 ///     data.0, data.1
 /// );
+///
+/// The `logger` argument accepts a value that implements the `Log` trait. The value
+/// will be borrowed within the macro.
+///
+/// Note that the global level set via Cargo features, or through `set_max_level` will
+/// still apply, even when a custom logger is supplied with the `logger` argument.
 #[macro_export]
 #[clippy::format_args]
 macro_rules! log {
@@ -378,6 +384,8 @@ macro_rules! trace {
 ///    debug!(target: "Global", "expensive debug data: {} {}", data.x, data.y);
 /// }
 /// ```
+///
+/// This macro accepts the same `target` and `logger` arguments as [`macro@log`].
 #[macro_export]
 macro_rules! log_enabled {
     // log_enabled!(logger: my_logger, target: "my_target", Level::Info)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -119,7 +119,7 @@ macro_rules! __log {
                 $crate::__private_api::format_args!($($arg)+),
                 lvl,
                 &($target, $crate::__private_api::module_path!(), $crate::__private_api::loc()),
-                &[$(($crate::__log_key!($key), $crate::__log_value!($key $(:$capture)* = $($value)*))),+]
+                &[$(($crate::__log_key!($key), $crate::__log_value!($key $(:$capture)* = $($value)*))),+] as &[_],
             );
         }
     });

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -63,6 +63,7 @@
 ///     "Received errors: {}, {}",
 ///     data.0, data.1
 /// );
+/// ```
 ///
 /// The `logger` argument accepts a value that implements the `Log` trait. The value
 /// will be borrowed within the macro.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,14 +3,6 @@
 use log::{debug, error, info, trace, warn, Level, LevelFilter, Log, Metadata, Record};
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "std")]
-use log::set_boxed_logger;
-
-#[cfg(not(feature = "std"))]
-fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
-    log::set_logger(Box::leak(logger))
-}
-
 struct State {
     last_log_level: Mutex<Option<Level>>,
     last_log_location: Mutex<Option<u32>>,

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -10,6 +10,7 @@ macro_rules! all_log_macros {
     });
 }
 
+// Not `Copy`
 struct Logger;
 
 impl Log for Logger {
@@ -22,6 +23,8 @@ impl Log for Logger {
 
 #[test]
 fn no_args() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
         log!(lvl, "hello");
         log!(lvl, "hello",);
@@ -29,8 +32,11 @@ fn no_args() {
         log!(target: "my_target", lvl, "hello");
         log!(target: "my_target", lvl, "hello",);
 
-        log!(lvl, "hello");
-        log!(lvl, "hello",);
+        log!(logger: logger, lvl, "hello");
+        log!(logger: logger, lvl, "hello",);
+
+        log!(logger: logger, target: "my_target", lvl, "hello");
+        log!(logger: logger, target: "my_target", lvl, "hello",);
     }
 
     all_log_macros!("hello");
@@ -39,10 +45,11 @@ fn no_args() {
     all_log_macros!(target: "my_target", "hello");
     all_log_macros!(target: "my_target", "hello",);
 
-    all_log_macros!(logger: Logger, "hello");
-    all_log_macros!(logger: Logger, "hello",);
-    all_log_macros!(logger: Logger, target: "my_target", "hello");
-    all_log_macros!(logger: Logger, target: "my_target", "hello",);
+    all_log_macros!(logger: logger, "hello");
+    all_log_macros!(logger: logger, "hello",);
+
+    all_log_macros!(logger: logger, target: "my_target", "hello");
+    all_log_macros!(logger: logger, target: "my_target", "hello",);
 }
 
 #[test]
@@ -63,6 +70,14 @@ fn anonymous_args() {
 
     all_log_macros!(target: "my_target", "hello {}", "world");
     all_log_macros!(target: "my_target", "hello {}", "world",);
+
+    let logger = Logger;
+
+    all_log_macros!(logger: logger, "hello {}", "world");
+    all_log_macros!(logger: logger, "hello {}", "world",);
+
+    all_log_macros!(logger: logger, target: "my_target", "hello {}", "world");
+    all_log_macros!(logger: logger, target: "my_target", "hello {}", "world",);
 }
 
 #[test]
@@ -83,6 +98,14 @@ fn named_args() {
 
     all_log_macros!(target: "my_target", "hello {world}", world = "world");
     all_log_macros!(target: "my_target", "hello {world}", world = "world",);
+
+    let logger = Logger;
+
+    all_log_macros!(logger: logger, "hello {world}", world = "world");
+    all_log_macros!(logger: logger, "hello {world}", world = "world",);
+
+    all_log_macros!(logger: logger, target: "my_target", "hello {world}", world = "world");
+    all_log_macros!(logger: logger, target: "my_target", "hello {world}", world = "world",);
 }
 
 #[test]
@@ -105,81 +128,136 @@ fn inlined_args() {
 
     all_log_macros!(target: "my_target", "hello {world}");
     all_log_macros!(target: "my_target", "hello {world}",);
+
+    let logger = Logger;
+
+    all_log_macros!(logger: logger, "hello {world}");
+    all_log_macros!(logger: logger, "hello {world}",);
+
+    all_log_macros!(logger: logger, target: "my_target", "hello {world}");
+    all_log_macros!(logger: logger, target: "my_target", "hello {world}",);
 }
 
 #[test]
 fn enabled() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
+        let _enabled = log_enabled!(lvl);
         let _enabled = log_enabled!(target: "my_target", lvl);
+        let _enabled = log_enabled!(logger: logger, target: "my_target", lvl);
+        let _enabled = log_enabled!(logger: logger, lvl);
     }
 }
 
 #[test]
 fn expr() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
         log!(lvl, "hello");
+
+        log!(logger: logger, lvl, "hello");
     }
 }
 
 #[test]
 #[cfg(feature = "kv")]
 fn kv_no_args() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
-
         log!(lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
+
+        log!(logger: logger, target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
+        log!(logger: logger, lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
     }
 
-    all_log_macros!(logger: Logger, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
-    all_log_macros!(logger: Logger, target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
     all_log_macros!(target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
     all_log_macros!(target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
     all_log_macros!(cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
+
+    all_log_macros!(logger: logger, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
+    all_log_macros!(logger: logger, target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello");
 }
 
 #[test]
 #[cfg(feature = "kv")]
 fn kv_expr_args() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
 
         log!(lvl, target = "my_target", cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
         log!(lvl, cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
+
+        log!(logger: logger, target: "my_target", lvl, cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
+
+        log!(logger: logger, lvl, target = "my_target", cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
+        log!(logger: logger, lvl, cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
     }
 
     all_log_macros!(target: "my_target", cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
     all_log_macros!(target = "my_target", cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
     all_log_macros!(cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
+
+    all_log_macros!(logger: logger, target: "my_target", cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
+    all_log_macros!(logger: logger, target = "my_target", cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
+    all_log_macros!(logger: logger, cat_math = { let mut x = 0; x += 1; x + 1 }; "hello");
 }
 
 #[test]
 #[cfg(feature = "kv")]
 fn kv_anonymous_args() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
         log!(lvl, target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
 
         log!(lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
+
+        log!(logger: logger, target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
+        log!(logger: logger, lvl, target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
+
+        log!(logger: logger, lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
     }
 
     all_log_macros!(target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
     all_log_macros!(target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
     all_log_macros!(cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
+
+    all_log_macros!(logger: logger, target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
+    all_log_macros!(logger: logger, target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
+    all_log_macros!(logger: logger, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {}", "world");
 }
 
 #[test]
 #[cfg(feature = "kv")]
 fn kv_named_args() {
+    let logger = Logger;
+
     for lvl in log::Level::iter() {
         log!(target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
         log!(lvl, target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
 
         log!(lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
+
+        log!(logger: logger, target: "my_target", lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
+        log!(logger: logger, lvl, target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
+
+        log!(logger: logger, lvl, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
     }
 
     all_log_macros!(target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
     all_log_macros!(target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
     all_log_macros!(cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
+
+    all_log_macros!(logger: logger, target: "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
+    all_log_macros!(logger: logger, target = "my_target", cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
+    all_log_macros!(logger: logger, cat_1 = "chashu", cat_2 = "nori", cat_count = 2; "hello {world}", world = "world");
 }
 
 #[test]
@@ -321,6 +399,20 @@ fn kv_serde() {
         a:serde = 42;
         "hello world"
     );
+}
+
+#[test]
+fn logger_short_lived() {
+    all_log_macros!(logger: Logger, "hello");
+    all_log_macros!(logger: &Logger, "hello");
+}
+
+#[test]
+fn logger_expr() {
+    all_log_macros!(logger: {
+        let logger = Logger;
+        logger
+    }, "hello");
 }
 
 /// Some and None (from Option) are used in the macros.


### PR DESCRIPTION
Follow-up to #664 

cc @EFanZh @tisonkun @Thomasdezeeuw 

This PR ensures we pass loggers by-ref when they're user-supplied, and by-value when it's the built-in global logger. I'll add a few tests to ensure we don't take ownership of the logger in `log!` or `log_enabled!`.