### PR TITLE
Is there any reason for some of these `struct`s not to implement `Copy`?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,7 +763,7 @@ impl<'a> MaybeStaticStr<'a> {
 /// [`log!`]: macro.log.html
 /// [`level()`]: struct.Record.html#method.level
 /// [`target()`]: struct.Record.html#method.target
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Record<'a> {
     metadata: Metadata<'a>,
     args: fmt::Arguments<'a>,
@@ -779,7 +779,7 @@ pub struct Record<'a> {
 // provides a useful `Debug` implementation for
 // the underlying `Source`.
 #[cfg(feature = "kv")]
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 struct KeyValues<'a>(&'a dyn kv::Source);
 
 #[cfg(feature = "kv")]
@@ -1079,7 +1079,7 @@ impl Default for RecordBuilder<'_> {
 ///
 /// # fn main(){}
 /// ```
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Metadata<'a> {
     level: Level,
     target: &'a str,


### PR DESCRIPTION
I saw that some of the structs that are part of the `Record` didn't implement the `Copy` trait. Is there any reason for this? If there is, I guess you can ignore this pull request, but in my use case, it would be kind of useful to be able to copy a `Record`, especially considering that nothing inside of a `Record` precludes it from implementing `Copy`, since it's all just references inside.