### PR TITLE
Unhide `#[derive(Debug)]` in example

### DIFF
--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -225,7 +225,7 @@
 //!
 //! ```
 //! # use log::kv::Key;
-//! # #[derive(Debug)]
+//! #[derive(Debug)]
 //! struct Data {
 //!     a: i32,
 //!     b: bool,


### PR DESCRIPTION
Makes no sense to hide this, as `impl Debug for Value` forwards to the `inner`'s `Debug` impl