### PR TITLE
fixes docs.rs anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,40 +61,40 @@ In order to produce log output, executables have to use a logger implementation 
 There are many available implementations to choose from, here are some options:
 
 * Simple minimal loggers:
-    * [`env_logger`](https://docs.rs/env_logger/*/env_logger/)
-    * [`colog`](https://docs.rs/colog/*/colog/)
-    * [`simple_logger`](https://docs.rs/simple_logger/*/simple_logger/)
-    * [`simplelog`](https://docs.rs/simplelog/*/simplelog/)
-    * [`pretty_env_logger`](https://docs.rs/pretty_env_logger/*/pretty_env_logger/)
-    * [`stderrlog`](https://docs.rs/stderrlog/*/stderrlog/)
-    * [`flexi_logger`](https://docs.rs/flexi_logger/*/flexi_logger/)
-    * [`call_logger`](https://docs.rs/call_logger/*/call_logger/)
-    * [`std-logger`](https://docs.rs/std-logger/*/std_logger/)
+    * [`env_logger`](https://docs.rs/env_logger/)
+    * [`colog`](https://docs.rs/colog/)
+    * [`simple_logger`](https://docs.rs/simple_logger/)
+    * [`simplelog`](https://docs.rs/simplelog/)
+    * [`pretty_env_logger`](https://docs.rs/pretty_env_logger/)
+    * [`stderrlog`](https://docs.rs/stderrlog/)
+    * [`flexi_logger`](https://docs.rs/flexi_logger/)
+    * [`call_logger`](https://docs.rs/call_logger/)
+    * [`std-logger`](https://docs.rs/std-logger/)
     * [`structured-logger`](https://docs.rs/structured-logger/latest/structured_logger/)
     * [`clang_log`](https://docs.rs/clang_log/latest/clang_log)
     * [`ftail`](https://docs.rs/ftail/latest/ftail/)
 * Complex configurable frameworks:
-    * [`log4rs`](https://docs.rs/log4rs/*/log4rs/)
-    * [`logforth`](https://docs.rs/logforth/*/logforth/)
-    * [`fern`](https://docs.rs/fern/*/fern/)
-    * [`spdlog-rs`](https://docs.rs/spdlog-rs/*/spdlog/)
+    * [`log4rs`](https://docs.rs/log4rs4rs/)
+    * [`logforth`](https://docs.rs/logforth/)
+    * [`fern`](https://docs.rs/fern/)
+    * [`spdlog-rs`](https://docs.rs/spdlog-rspdlog/)
 * Adaptors for other facilities:
-    * [`syslog`](https://docs.rs/syslog/*/syslog/)
-    * [`systemd-journal-logger`](https://docs.rs/systemd-journal-logger/*/systemd_journal_logger/)
-    * [`slog-stdlog`](https://docs.rs/slog-stdlog/*/slog_stdlog/)
-    * [`android_log`](https://docs.rs/android_log/*/android_log/)
-    * [`win_dbg_logger`](https://docs.rs/win_dbg_logger/*/win_dbg_logger/)
-    * [`db_logger`](https://docs.rs/db_logger/*/db_logger/)
-    * [`log-to-defmt`](https://docs.rs/log-to-defmt/*/log_to_defmt/)
-    * [`logcontrol-log`](https://docs.rs/logcontrol-log/*/logcontrol_log/)
+    * [`syslog`](https://docs.rs/syslog/)
+    * [`systemd-journal-logger`](https://docs.rs/systemd-journal-logger/)
+    * [`slog-stdlog`](https://docs.rs/slog-stdlog/)
+    * [`android_log`](https://docs.rs/android_log/)
+    * [`win_dbg_logger`](https://docs.rs/win_dbg_logger/)
+    * [`db_logger`](https://docs.rs/db_logger/)
+    * [`log-to-defmt`](https://docs.rs/log-to-defmt/)
+    * [`logcontrol-log`](https://docs.rs/logcontrol-logcontrol_log/)
 * For WebAssembly binaries:
-    * [`console_log`](https://docs.rs/console_log/*/console_log/)
+    * [`console_log`](https://docs.rs/console_log/)
 * For dynamic libraries:
     * You may need to construct [an FFI-safe wrapper over `log`](https://github.com/rust-lang/log/issues/421) to initialize in your libraries.
 * Utilities:
-    * [`log_err`](https://docs.rs/log_err/*/log_err/)
-    * [`log-reload`](https://docs.rs/log-reload/*/log_reload/)
-    * [`alterable_logger`](https://docs.rs/alterable_logger/*/alterable_logger)
+    * [`log_err`](https://docs.rs/log_err/)
+    * [`log-reload`](https://docs.rs/log-reload/)
+    * [`alterable_logger`](https://docs.rs/alterable_logger)
 
 Executables should choose a logger implementation and initialize it early in the
 runtime of the program. Logger implementations will typically include a


### PR DESCRIPTION
This fixes several broken anchors to the documentation of other rust crates related to the `log` one.