### PR TITLE
Point to new URLs for favicon and logo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,8 +342,8 @@
 //! [ftail]: https://docs.rs/ftail/latest/ftail
 
 #![doc(
-    html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-    html_favicon_url = "https://www.rust-lang.org/favicon.ico",
+    html_logo_url = "https://prev.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+    html_favicon_url = "https://prev.rust-lang.org/favicon.ico",
     html_root_url = "https://docs.rs/log/0.4.28"
 )]
 #![warn(missing_docs)]


### PR DESCRIPTION
Logos and favicon links for the docs are broken, this changes the URLs to point to the new location