### PR TITLE
perf: reduce llvm-lines of FromStr for `Level` and `LevelFilter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,14 +515,13 @@ impl PartialOrd<LevelFilter> for Level {
 impl FromStr for Level {
     type Err = ParseLevelError;
     fn from_str(level: &str) -> Result<Level, Self::Err> {
-        LOG_LEVEL_NAMES
-            .iter()
-            .position(|&name| name.eq_ignore_ascii_case(level))
-            .into_iter()
-            .filter(|&idx| idx != 0)
-            .map(|idx| Level::from_usize(idx).unwrap())
-            .next()
-            .ok_or(ParseLevelError(()))
+        // iterate from 1, excluding "OFF"
+        for idx in 1..LOG_LEVEL_NAMES.len() {
+            if LOG_LEVEL_NAMES[idx].eq_ignore_ascii_case(level) {
+                return Ok(Level::from_usize(idx).unwrap());
+            }
+        }
+        Err(ParseLevelError(()))
     }
 }
 
@@ -666,11 +665,13 @@ impl PartialOrd<Level> for LevelFilter {
 impl FromStr for LevelFilter {
     type Err = ParseLevelError;
     fn from_str(level: &str) -> Result<LevelFilter, Self::Err> {
-        LOG_LEVEL_NAMES
-            .iter()
-            .position(|&name| name.eq_ignore_ascii_case(level))
-            .map(|p| LevelFilter::from_usize(p).unwrap())
-            .ok_or(ParseLevelError(()))
+        // iterate from 0, including "OFF"
+        for idx in 0..LOG_LEVEL_NAMES.len() {
+            if LOG_LEVEL_NAMES[idx].eq_ignore_ascii_case(level) {
+                return Ok(LevelFilter::from_usize(idx).unwrap());
+            }
+        }
+        Err(ParseLevelError(()))
     }
 }
 


### PR DESCRIPTION
This PR improves compile times.

599 less llvm-lines (tested with `std` feature).


Before:
```shell
$ cargo llvm-lines -F std | head -n 10
   Compiling log v0.4.28 (./log)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.50s
  Lines               Copies            Function name
  -----               ------            -------------
  2063                94                (TOTAL)
   214 (10.4%, 10.4%)  1 (1.1%,  1.1%)  core::sync::atomic::atomic_compare_exchange
   168 (8.1%, 18.5%)   2 (2.1%,  3.2%)  <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::position
   163 (7.9%, 26.4%)   2 (2.1%,  5.3%)  log::set_logger_inner
    98 (4.8%, 31.2%)   1 (1.1%,  6.4%)  core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case
    89 (4.3%, 35.5%)   1 (1.1%,  7.4%)  core::iter::traits::iterator::Iterator::try_fold
    56 (2.7%, 38.2%)   1 (1.1%,  8.5%)  core::sync::atomic::atomic_load
    53 (2.6%, 40.8%)   1 (1.1%,  9.6%)  core::sync::atomic::atomic_store
```

After:
```shell
$ cargo llvm-lines -F std | head -n 10
   Compiling log v0.4.28 (./log)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
  Lines               Copies            Function name
  -----               ------            -------------
  1464                71                (TOTAL)
   214 (14.6%, 14.6%)  1 (1.4%,  1.4%)  core::sync::atomic::atomic_compare_exchange
   163 (11.1%, 25.8%)  2 (2.8%,  4.2%)  log::set_logger_inner
    98 (6.7%, 32.4%)   1 (1.4%,  5.6%)  core::slice::ascii::<impl [u8]>::eq_ignore_ascii_case
    56 (3.8%, 36.3%)   1 (1.4%,  7.0%)  core::sync::atomic::atomic_load
    53 (3.6%, 39.9%)   1 (1.4%,  8.5%)  core::sync::atomic::atomic_store
    51 (3.5%, 43.4%)   1 (1.4%,  9.9%)  <alloc::boxed::Box<T,A> as core::ops::drop::Drop>::drop
    48 (3.3%, 46.7%)   1 (1.4%, 11.3%)  <log::Level as core::str::traits::FromStr>::from_str
```
