### PR TITLE
Remove implicit features from feature matrix in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,8 @@ jobs:
         rustup update ${{ matrix.rust }} --no-self-update
         rustup default ${{ matrix.rust }}
         cargo +stable install cargo-hack --locked
-    - run: cargo hack test --feature-powerset --exclude-features max_level_off,max_level_error,max_level_warn,max_level_info,max_level_debug,max_level_trace,release_max_level_off,release_max_level_error,release_max_level_warn,release_max_level_info,release_max_level_debug,release_max_level_trace
+    - run: cargo hack test --feature-powerset --exclude-features max_level_off,max_level_error,max_level_warn,max_level_info,max_level_debug,max_level_trace,release_max_level_off,release_max_level_error,release_max_level_warn,release_max_level_info,release_max_level_debug,release_max_level_trace,serde,sval,sval_ref,value-bag
+
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
     - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
 
@@ -116,7 +117,7 @@ jobs:
           rustup update 1.61.0 --no-self-update
           rustup default 1.61.0
           cargo +stable install cargo-hack --locked
-      - run: cargo hack test --feature-powerset --exclude-features max_level_off,max_level_error,max_level_warn,max_level_info,max_level_debug,max_level_trace,release_max_level_off,release_max_level_error,release_max_level_warn,release_max_level_info,release_max_level_debug,release_max_level_trace
+      - run: cargo hack test --feature-powerset --exclude-features max_level_off,max_level_error,max_level_warn,max_level_info,max_level_debug,max_level_trace,release_max_level_off,release_max_level_error,release_max_level_warn,release_max_level_info,release_max_level_debug,release_max_level_trace,serde,sval,sval_ref,value-bag
       - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
       - run: cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
 


### PR DESCRIPTION
The serde, sval, sval_ref and value-bag "features" are implicitly created because they are optional dependencies. However, we don't really treat them as features and use kv_{sval,serde} for this instead.

Exclude these feature from the CI matrix when testing to avoid testing them twice.