### PR TITLE
Prepare for 0.4.29 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.4.29] - 2025-12-02
+
+## What's Changed
+* perf: reduce llvm-lines of FromStr for `Level` and `LevelFilter` by @dishmaker in https://github.com/rust-lang/log/pull/709
+* Replace serde with serde_core by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/712
+
+## New Contributors
+* @AldaronLau made their first contribution in https://github.com/rust-lang/log/pull/703
+* @dishmaker made their first contribution in https://github.com/rust-lang/log/pull/709
+
+**Full Changelog**: https://github.com/rust-lang/log/compare/0.4.28...0.4.29
+
 ## [0.4.28] - 2025-09-02
 
 ## What's Changed
@@ -377,7 +389,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.28...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.29...HEAD
+[0.4.29]: https://github.com/rust-lang/log/compare/0.4.28...0.4.29
 [0.4.28]: https://github.com/rust-lang/log/compare/0.4.27...0.4.28
 [0.4.27]: https://github.com/rust-lang/log/compare/0.4.26...0.4.27
 [0.4.26]: https://github.com/rust-lang/log/compare/0.4.25...0.4.26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.28" # remember to update html_root_url
+version = "0.4.29" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@
 #![doc(
     html_logo_url = "https://prev.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://prev.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.28"
+    html_root_url = "https://docs.rs/log/0.4.29"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
## What's Changed
* docs: Add missing impls from README.md by @AldaronLau in https://github.com/rust-lang/log/pull/703
* Point to new URLs for favicon and logo by @AldaronLau in https://github.com/rust-lang/log/pull/704
* perf: reduce llvm-lines of FromStr for `Level` and `LevelFilter` by @dishmaker in https://github.com/rust-lang/log/pull/709
* Replace serde with serde_core by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/712
* Fix clippy lints by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/713
* Use GitHub Actions to install Rust and cargo-hack by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/715
* Exclude old unstable_kv features from testing matrix by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/716
* Fix up CI by @KodrAus in https://github.com/rust-lang/log/pull/718

## New Contributors
* @AldaronLau made their first contribution in https://github.com/rust-lang/log/pull/703
* @dishmaker made their first contribution in https://github.com/rust-lang/log/pull/709

**Full Changelog**: https://github.com/rust-lang/log/compare/0.4.28...0.4.29