### PR TITLE
Update MSRV in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ implementation that is most suitable for its use case.
 
 ## Minimum supported `rustc`
 
-`1.61.0+`
+`1.68.0+`
 
 This version is explicitly tested in CI and may be bumped in any release as needed. Maintaining compatibility with older compilers is a priority though, so the bar for bumping the minimum supported version is set very high. Any changes to the supported minimum version will be called out in the release notes.
 


### PR DESCRIPTION
The MSRV was explicitly bumped to 1.68.0 in https://github.com/rust-lang/log/pull/718. This fixes the README to reflect that.