### PR TITLE
Prepare for 0.4.30 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 **Full Changelog**: https://github.com/rust-lang/log/compare/0.4.29...0.4.30
 
+### Notable Changes
+* MSRV is bumped to 1.71.0 in https://github.com/rust-lang/log/pull/723
+
 ## [0.4.29] - 2025-12-02
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 ## [Unreleased]
 
+## [0.4.30] - 2026-05-21
+
+### What's Changed
+* Support capturing of `std::net` types by @KodrAus in https://github.com/rust-lang/log/pull/724
+
+### New Contributors
+* @V0ldek made their first contribution in https://github.com/rust-lang/log/pull/720
+* @woodruffw made their first contribution in https://github.com/rust-lang/log/pull/723
+
+**Full Changelog**: https://github.com/rust-lang/log/compare/0.4.29...0.4.30
+
 ## [0.4.29] - 2025-12-02
 
-## What's Changed
+### What's Changed
 * perf: reduce llvm-lines of FromStr for `Level` and `LevelFilter` by @dishmaker in https://github.com/rust-lang/log/pull/709
 * Replace serde with serde_core by @Thomasdezeeuw in https://github.com/rust-lang/log/pull/712
 
-## New Contributors
+### New Contributors
 * @AldaronLau made their first contribution in https://github.com/rust-lang/log/pull/703
 * @dishmaker made their first contribution in https://github.com/rust-lang/log/pull/709
 
@@ -16,7 +27,7 @@
 
 ## [0.4.28] - 2025-09-02
 
-## What's Changed
+### What's Changed
 * ci: drop really old trick and ensure MSRV for all feature combo by @tisonkun in https://github.com/rust-lang/log/pull/676
 * Chore: delete compare_exchange method for AtomicUsize on platforms without atomics  by @HaoliangXu in https://github.com/rust-lang/log/pull/690
 * Add `increment_severity()` and `decrement_severity()` methods for `Level` and `LevelFilter` by @nebkor in https://github.com/rust-lang/log/pull/692
@@ -389,7 +400,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.29...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.30...HEAD
+[0.4.30]: https://github.com/rust-lang/log/compare/0.4.29...0.4.30
 [0.4.29]: https://github.com/rust-lang/log/compare/0.4.28...0.4.29
 [0.4.28]: https://github.com/rust-lang/log/compare/0.4.27...0.4.28
 [0.4.27]: https://github.com/rust-lang/log/compare/0.4.26...0.4.27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.29" # remember to update html_root_url
+version = "0.4.30" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ implementation that is most suitable for its use case.
 
 ## Minimum supported `rustc`
 
-`1.68.0+`
+See the `rust-version` field in `Cargo.toml` for the current minimum Rust toolchain version.
 
 This version is explicitly tested in CI and may be bumped in any release as needed. Maintaining compatibility with older compilers is a priority though, so the bar for bumping the minimum supported version is set very high. Any changes to the supported minimum version will be called out in the release notes.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,7 @@
 #![doc(
     html_logo_url = "https://prev.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://prev.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.29"
+    html_root_url = "https://docs.rs/log/0.4.30"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations, unconditional_recursion)]


### PR DESCRIPTION
https://github.com/rust-lang/log/compare/0.4.29...main