### PR TITLE
fix typos in kv compile errors and log documentation

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -68,7 +68,7 @@
 /// The `logger` argument accepts a value that implements the `Log` trait. The value
 /// will be borrowed within the macro.
 ///
-/// Note that the global level set via Cargo features, or through `set_max_level` will
+/// Note that the global level set via Cargo features or through `set_max_level` will
 /// still apply, even when a custom logger is supplied with the `logger` argument.
 #[macro_export]
 #[clippy::format_args]
@@ -534,7 +534,7 @@ macro_rules! __log_value_sval {
 #[cfg(not(feature = "kv_sval"))]
 macro_rules! __log_value_sval {
     ($args:expr) => {
-        compile_error!("capturing values as `sval::Value` requites the `kv_sval` feature of `log`")
+        compile_error!("capturing values as `sval::Value` requires the `kv_sval` feature of `log`")
     };
 }
 
@@ -553,7 +553,7 @@ macro_rules! __log_value_serde {
 macro_rules! __log_value_serde {
     ($args:expr) => {
         compile_error!(
-            "capturing values as `serde::Serialize` requites the `kv_serde` feature of `log`"
+            "capturing values as `serde::Serialize` requires the `kv_serde` feature of `log`"
         )
     };
 }
@@ -573,7 +573,7 @@ macro_rules! __log_value_error {
 macro_rules! __log_value_error {
     ($args:expr) => {
         compile_error!(
-            "capturing values as `std::error::Error` requites the `kv_std` feature of `log`"
+            "capturing values as `std::error::Error` requires the `kv_std` feature of `log`"
         )
     };
 }


### PR DESCRIPTION
### Description
This PR fixes minor typographical errors within the `log` crate:
1. Fixes spelling mistakes in several `compile_error!` macros under the `kv` feature flags, changing `requites` to `requires`.
2. Removes an unnecessary comma in the `log!` macro documentation block for better readability.

### Type of Change
- [x] Documentation update / Minor text fix (non-breaking change to docs and compiler error messages)

### Checklist
- [x] I have ran `cargo test --features "kv kv_sval kv_serde kv_std"` locally and all tests passed (including doc-tests).