### PR TITLE
kv::std_support may not need value-bag

### DIFF
--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -415,7 +415,7 @@ impl<'v> Value<'v> {
     }
 }
 
-#[cfg(feature = "kv_std")]
+#[cfg(all(feature = "kv", feature = "std"))]
 mod std_support {
     use std::borrow::Cow;
     use std::rc::Rc;
@@ -462,6 +462,7 @@ mod std_support {
         }
     }
 
+    #[cfg(feature = "kv_std")]
     impl<'v> Value<'v> {
         /// Try convert this value into a string.
         pub fn to_cow_str(&self) -> Option<Cow<'v, str>> {

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -415,7 +415,7 @@ impl<'v> Value<'v> {
     }
 }
 
-#[cfg(all(feature = "kv", feature = "std"))]
+#[cfg(feature = "std")]
 mod std_support {
     use std::borrow::Cow;
     use std::rc::Rc;


### PR DESCRIPTION
Exclude `value-bag` from the dependency tree when we don't need it.

The code would still leverage `value-bag` if it is enabled, thanks to the Value inner design.

cc @KodrAus 