### PR TITLE
doc: Add context-logger utility to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ There are many available implementations to choose from, here are some options:
     * [`log_err`](https://docs.rs/log_err/*/log_err/)
     * [`log-reload`](https://docs.rs/log-reload/*/log_reload/)
     * [`alterable_logger`](https://docs.rs/alterable_logger/*/alterable_logger)
+    * [`context-logger`](https://docs.rs/context-logger/*/context_logger)
 
 Executables should choose a logger implementation and initialize it early in the
 runtime of the program. Logger implementations will typically include a


### PR DESCRIPTION
A lightweight, ergonomic library for adding structured context to your logs.

context-logger enhances the standard Rust [log](https://crates.io/crates/log) crate ecosystem by allowing you to attach rich contextual information to your log messages without changing your existing logging patterns.

